### PR TITLE
mdb_cursor_put params should be refs?

### DIFF
--- a/src/LightningDB/INativeLibraryFacade.cs
+++ b/src/LightningDB/INativeLibraryFacade.cs
@@ -477,7 +477,7 @@ namespace LightningDB
         ///     EACCES - an attempt was made to modify a read-only database.
         ///     EINVAL - an invalid parameter was specified.
         /// </returns>
-        int mdb_cursor_put(IntPtr cursor, ValueStructure key, ValueStructure data, PutOptions flags); //OK
+        int mdb_cursor_put(IntPtr cursor, ref ValueStructure key, ref ValueStructure data, PutOptions flags); //OK
 
         /// <summary>
         /// Delete current key/data pair.

--- a/src/LightningDB/LightningCursor.cs
+++ b/src/LightningDB/LightningCursor.cs
@@ -179,7 +179,7 @@ namespace LightningDB
                 var keyStruct = keyMarshalStruct.ValueStructure;
                 var valueStruct = valueMarshalStruct.ValueStructure;
 
-                Native.Execute(lib => lib.mdb_cursor_put(_handle, keyStruct, valueStruct, options));
+                Native.Execute(lib => lib.mdb_cursor_put(_handle, ref keyStruct, ref valueStruct, options));
             }
         }
 

--- a/src/LightningDB/NativeLibraryFacades.cs
+++ b/src/LightningDB/NativeLibraryFacades.cs
@@ -103,7 +103,7 @@ namespace LightningDB
         private static extern int mdb_cursor_get(IntPtr cursor, ref ValueStructure key, ref ValueStructure data, CursorOperation op);
 
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
-        private static extern int mdb_cursor_put(IntPtr cursor, ValueStructure key, ValueStructure data, PutOptions flags);
+        private static extern int mdb_cursor_put(IntPtr cursor, ref ValueStructure key, ref ValueStructure data, PutOptions flags);
 
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
         private static extern int mdb_cursor_del(IntPtr cursor, CursorDeleteOption flags);
@@ -263,9 +263,9 @@ namespace LightningDB
             return Native32BitLibraryFacade.mdb_cursor_get(cursor, ref key, ref data, op);
         }
 
-        int INativeLibraryFacade.mdb_cursor_put(IntPtr cursor, ValueStructure key, ValueStructure data, PutOptions flags)
+        int INativeLibraryFacade.mdb_cursor_put(IntPtr cursor, ref ValueStructure key, ref ValueStructure data, PutOptions flags)
         {
-            return Native32BitLibraryFacade.mdb_cursor_put(cursor, key, data, flags);
+            return Native32BitLibraryFacade.mdb_cursor_put(cursor, ref key, ref data, flags);
         }
 
         int INativeLibraryFacade.mdb_cursor_del(IntPtr cursor, CursorDeleteOption flags)
@@ -366,7 +366,7 @@ namespace LightningDB
         private static extern int mdb_cursor_get(IntPtr cursor, ref ValueStructure key, ref ValueStructure data, CursorOperation op);
 
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
-        private static extern int mdb_cursor_put(IntPtr cursor, ValueStructure key, ValueStructure data, PutOptions flags);
+        private static extern int mdb_cursor_put(IntPtr cursor, ref ValueStructure key, ref ValueStructure data, PutOptions flags);
 
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
         private static extern int mdb_cursor_del(IntPtr cursor, CursorDeleteOption flags);
@@ -515,9 +515,9 @@ namespace LightningDB
             return Native64BitLibraryFacade.mdb_cursor_get(cursor, ref key, ref data, op);
         }
 
-        int INativeLibraryFacade.mdb_cursor_put(IntPtr cursor, ValueStructure key, ValueStructure data, PutOptions flags)
+        int INativeLibraryFacade.mdb_cursor_put(IntPtr cursor, ref ValueStructure key, ref ValueStructure data, PutOptions flags)
         {
-            return Native64BitLibraryFacade.mdb_cursor_put(cursor, key, data, flags);
+            return Native64BitLibraryFacade.mdb_cursor_put(cursor, ref key, ref data, flags);
         }
 
         int INativeLibraryFacade.mdb_cursor_del(IntPtr cursor, CursorDeleteOption flags)
@@ -618,7 +618,7 @@ namespace LightningDB
         private static extern int mdb_cursor_get(IntPtr cursor, ref ValueStructure key, ref ValueStructure data, CursorOperation op);
 
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
-        private static extern int mdb_cursor_put(IntPtr cursor, ValueStructure key, ValueStructure data, PutOptions flags);
+        private static extern int mdb_cursor_put(IntPtr cursor, ref ValueStructure key, ref ValueStructure data, PutOptions flags);
 
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
         private static extern int mdb_cursor_del(IntPtr cursor, CursorDeleteOption flags);
@@ -778,9 +778,9 @@ namespace LightningDB
             return FallbackLibraryFacade.mdb_cursor_get(cursor, ref key, ref data, op);
         }
 
-        int INativeLibraryFacade.mdb_cursor_put(IntPtr cursor, ValueStructure key, ValueStructure data, PutOptions flags)
+        int INativeLibraryFacade.mdb_cursor_put(IntPtr cursor, ref ValueStructure key, ref ValueStructure data, PutOptions flags)
         {
-            return FallbackLibraryFacade.mdb_cursor_put(cursor, key, data, flags);
+            return FallbackLibraryFacade.mdb_cursor_put(cursor, ref key, ref data, flags);
         }
 
         int INativeLibraryFacade.mdb_cursor_del(IntPtr cursor, CursorDeleteOption flags)

--- a/src/LightningDB/NativeLibraryFacades.tt
+++ b/src/LightningDB/NativeLibraryFacades.tt
@@ -113,7 +113,7 @@ namespace LightningDB
         private static extern int mdb_cursor_get(IntPtr cursor, ref ValueStructure key, ref ValueStructure data, CursorOperation op);
 
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
-        private static extern int mdb_cursor_put(IntPtr cursor, ValueStructure key, ValueStructure data, PutOptions flags);
+        private static extern int mdb_cursor_put(IntPtr cursor, ref ValueStructure key, ref ValueStructure data, PutOptions flags);
 
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
         private static extern int mdb_cursor_del(IntPtr cursor, CursorDeleteOption flags);


### PR DESCRIPTION
I got a crash trying to use LightningCursor.Put(). Comparing the code to Transaction.Put(), it appears that the key/value params ought to be references. Yes? Not sure, haven't used C# much.
