### PR TITLE
Fixed bug with Compare delegate lifetime

### DIFF
--- a/src/LightningDB/DatabaseOptions.cs
+++ b/src/LightningDB/DatabaseOptions.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using LightningDB.Native;
 
 namespace LightningDB
 {
@@ -25,52 +22,5 @@ namespace LightningDB
         public DatabaseOpenFlags Flags { get; set; }
 
         #endregion
-
-        private static CompareFunction CreateNativeCompareFunction(
-            LightningDatabase db, LightningCompareDelegate compare)
-        {
-            return (IntPtr left, IntPtr right) =>
-                compare.Invoke(db, NativeMethods.ValueByteArrayFromPtr(left), NativeMethods.ValueByteArrayFromPtr(right));
-        }
-
-        private static void SetNativeCompareFunction(
-            LightningTransaction tran, 
-            LightningDatabase db,
-            Func<CompareFunctionBuilder, LightningCompareDelegate> delegateFactory,
-            Func<INativeLibraryFacade, CompareFunction, int> setter)
-        {
-            if (delegateFactory == null)
-                return;
-
-            var comparer = delegateFactory.Invoke(new CompareFunctionBuilder());
-            if (comparer == null)
-                return;
-
-            var compareFunction = CreateNativeCompareFunction(db, comparer);
-
-            NativeMethods.Execute(lib => setter.Invoke(lib, compareFunction));
-            tran.SubTransactionsManager.StoreComparer(comparer);
-        }
-
-        internal void SetComparer(LightningTransaction tran, LightningDatabase db)
-        {
-            SetNativeCompareFunction(
-                tran,
-                db,
-                Compare,
-                (lib, func) => lib.mdb_set_compare(tran._handle, db._handle, func));
-        }
-
-        internal void SetDuplicatesSort(LightningTransaction tran, LightningDatabase db)
-        {
-            if (!db.OpenFlags.HasFlag(DatabaseOpenFlags.DuplicatesSort))
-                return;
-
-            SetNativeCompareFunction(
-                tran,
-                db,
-                DuplicatesSort,
-                (lib, func) => lib.mdb_set_dupsort(tran._handle, db._handle, func));
-        }
     }
 }

--- a/src/LightningDB/LightningTransaction.cs
+++ b/src/LightningDB/LightningTransaction.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Runtime.InteropServices;
-using System.Text;
 using LightningDB.Factories;
 using LightningDB.Native;
 
@@ -82,8 +80,8 @@ namespace LightningDB
 
             var db = this.Environment.OpenDatabase(name, this, options.Flags, options.Encoding);
 
-            options.SetComparer(this, db);
-            options.SetDuplicatesSort(this, db);
+            db.SetComparer(this, options.Compare);
+            db.SetDuplicatesSort(this, options.DuplicatesSort);
 
             return db;
         }


### PR DESCRIPTION
Hi, thanks for the great project!

I've found a bug using custom Compare functions. The DatabaseOptions class created a delegate to perform the comparison but it doesn't store a reference so the delegate doesn't survive garbage collection. I've created a new test that forces garbage collection to show the problem. I've fixed it by moving the SetComparer() logic into the LightningDatabase class and kept a reference to the delegate in the LightningDatabase object.

I've tried to keep everything matching the current style of the project. Let me know what you think of the fix.

Thanks
