### PR TITLE
Switch to GitHub-hosted LMDB submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "mdb"]
 	path = mdb
-	url = git://gitorious.org/mdb/mdb.git
+	url = https://github.com/LMDB/lmdb.git


### PR DESCRIPTION
gitorious.org is shutting down and the official LMDB Git mirror is now
on GitHub.
