### PR TITLE
Fix UsedSize calculation to account for free pages

### DIFF
--- a/src/LightningDB/LightningEnvironment.cs
+++ b/src/LightningDB/LightningEnvironment.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Text;
 using LightningDB.Converters;
 using LightningDB.Factories;
@@ -120,7 +121,32 @@ namespace LightningDB
                 var envInfo = new MDBEnvInfo();
                 NativeMethods.Execute(lib => lib.mdb_env_info(_handle, out envInfo));
 
-                return envInfo.me_last_pgno.ToInt64() * PageSize;
+                return ((envInfo.me_last_pgno.ToInt64() + 1) - this.FreePages) * PageSize;
+            }
+        }
+
+        public long FreePages
+        {
+            get
+            {
+                long freePages = 0;
+                using (var txn = this.BeginTransaction(TransactionBeginFlags.ReadOnly))
+                {
+                    var cursorHandle = default(IntPtr);
+                    NativeMethods.Execute(lib => lib.mdb_cursor_open(txn._handle, 0, out cursorHandle));
+
+                    var keyStruct = new ValueStructure();
+                    var valueStruct = new ValueStructure();
+                    while (NativeMethods.Read(lib => lib.mdb_cursor_get(cursorHandle, ref keyStruct, ref valueStruct, CursorOperation.Next)) == 0)
+                    {
+                        IntPtr freeListData = valueStruct.data;
+                        freePages += Marshal.ReadIntPtr(freeListData).ToInt64();
+                    }
+
+                    NativeMethods.Library.mdb_cursor_close(cursorHandle);
+                }
+
+                return freePages;
             }
         }
 


### PR DESCRIPTION
UsedSize now references the new FreePages property, which counts up the number of free pages in the same manner as LMDB's mdb_stat.c tool.

Commit 8cd1bcd implemented the initial part of this logic, but per @hyc's comment in issue #32 (on January 12th) we should also account for the number of free pages when calculating database usage.
