### PR TITLE
using the right override of Get in MoveToAndGet

### DIFF
--- a/src/LightningDB/LightningCursor.cs
+++ b/src/LightningDB/LightningCursor.cs
@@ -83,7 +83,7 @@ namespace LightningDB
         /// <returns>Returns true if the key was found.</returns>
         public bool MoveToAndGet(byte[] key)
         {
-            return Get(CursorOperation.SetKey);
+            return Get(CursorOperation.SetKey, key);
         }
 
         /// <summary>


### PR DESCRIPTION
I didnt get the project to build, but i assume that the wrong override of the Get method was used and that it should also take the key parameter in MoveToAndGet
