### PR TITLE
fixes link to docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ using (var tx = env.BeginTransaction(TransactionBeginFlags.ReadOnly))
 
 More examples can be found in the unit tests.
 
-[Official LMDB API docs](http://symas.com/mdb/doc/group__mdb.html)
+<a href="http://lmdb.tech/doc" target="_blank">Official LMDB API docs</a>
 
 Library is available from NuGet: https://www.nuget.org/packages/LightningDB/
 


### PR DESCRIPTION
The current link leads to 404. I changed it. Also tried to make it open in a new tab, however, seems like github removes target attribute.