### PR TITLE
This fixes whole key deletes in a DuplicatesSort database.

### DIFF
--- a/src/LightningDB.Tests/DatabaseIOTests.cs
+++ b/src/LightningDB.Tests/DatabaseIOTests.cs
@@ -68,6 +68,29 @@ namespace LightningDB.Tests
         }
 
         [Fact]
+        public void DatabaseDeleteShouldRemoveAllDuplicateDataItems()
+        {
+            var fs = new SharedFileSystem();
+            using (var env = new LightningEnvironment(fs.CreateNewDirectoryForTest(), configuration: new EnvironmentConfiguration {MapSize = 1024 * 1024, MaxDatabases = 1}))
+            {
+                env.Open();
+                using (var tx = env.BeginTransaction())
+                using (var db = tx.OpenDatabase(configuration: new DatabaseConfiguration() { Flags = DatabaseOpenFlags.DuplicatesSort}))
+                {
+                    var key = "key";
+                    var value1 = "value1";
+                    var value2 = "value2";
+
+                    tx.Put(db, key, value1);
+                    tx.Put(db, key, value2);
+
+                    tx.Delete(db, key);
+                    Assert.False(tx.ContainsKey(db, key));
+                }
+            }
+        }
+
+        [Fact]
         public void ContainsKeyShouldReturnTrueIfKeyExists()
         {
             var key = "key";

--- a/src/LightningDB/Native/Lmdb.cs
+++ b/src/LightningDB/Native/Lmdb.cs
@@ -224,9 +224,8 @@ namespace LightningDB.Native
 
         public static int mdb_del(IntPtr txn, uint dbi, byte[] key)
         {
-            ValueStructure val = default(ValueStructure);
             using(var marshal = new MarshalValueStructure(key))
-                return check(LmdbMethods.mdb_del(txn, dbi, ref marshal.Key, ref val));
+                return check(LmdbMethods.mdb_del(txn, dbi, ref marshal.Key, IntPtr.Zero));
         }
 
         public static int mdb_cursor_open(IntPtr txn, uint dbi, out IntPtr cursor)

--- a/src/LightningDB/Native/LmdbMethods.cs
+++ b/src/LightningDB/Native/LmdbMethods.cs
@@ -84,6 +84,9 @@ namespace LightningDB.Native
         public static extern int mdb_del(IntPtr txn, uint dbi, ref ValueStructure key, ref ValueStructure data);
 
         [DllImport("lmdb", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int mdb_del(IntPtr txn, uint dbi, ref ValueStructure key, IntPtr data);
+
+        [DllImport("lmdb", CallingConvention = CallingConvention.Cdecl)]
         public static extern int mdb_cursor_open(IntPtr txn, uint dbi, out IntPtr cursor);
 
         [DllImport("lmdb", CallingConvention = CallingConvention.Cdecl)]


### PR DESCRIPTION
Previously a `ValueStructure` with null fields was being passed to LMDB for the delete and it was throwing an exception (MDB_BAD_VALSIZE).

LMDB wants a null pointer there (not a `ValueStruct` with null fields). I added a native overload that accepts an `IntPtr` instead of `ValueStructure` for the data item and call it from the appropriate place.