### PR TITLE
Add a basic write benchmark

### DIFF
--- a/Lightning.Net.sln
+++ b/Lightning.Net.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26228.4
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30204.135
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LightningDB", "src\LightningDB\LightningDB.csproj", "{C864E62B-5C53-479C-9A6F-6D086E1EC3DF}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LightningDB.Tests", "src\LightningDB.Tests\LightningDB.Tests.csproj", "{3A8F29FB-1110-4755-9700-4EB064BB463E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SecondProcess", "src\SecondProcess\SecondProcess.csproj", "{9621DE3C-6C1A-484F-8DE7-C8F4D6F71EA9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SecondProcess", "src\SecondProcess\SecondProcess.csproj", "{9621DE3C-6C1A-484F-8DE7-C8F4D6F71EA9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LightningDB.Benchmarks", "src\LightningDB.Benchmarks\LightningDB.Benchmarks.csproj", "{C28814DF-2BC4-4F0A-AF13-86B8B0CB68C6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,8 +29,15 @@ Global
 		{9621DE3C-6C1A-484F-8DE7-C8F4D6F71EA9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9621DE3C-6C1A-484F-8DE7-C8F4D6F71EA9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9621DE3C-6C1A-484F-8DE7-C8F4D6F71EA9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C28814DF-2BC4-4F0A-AF13-86B8B0CB68C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C28814DF-2BC4-4F0A-AF13-86B8B0CB68C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C28814DF-2BC4-4F0A-AF13-86B8B0CB68C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C28814DF-2BC4-4F0A-AF13-86B8B0CB68C6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A9864EE9-A41B-4A4D-9CE9-595A2779AB44}
 	EndGlobalSection
 EndGlobal

--- a/src/LightningDB.Benchmarks/Benchmarks.cs
+++ b/src/LightningDB.Benchmarks/Benchmarks.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.IO;
+using System.Runtime.InteropServices;
+using BenchmarkDotNet;
+using BenchmarkDotNet.Attributes;
+
+using LightningDB;
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace LightningDB.Benchmarks
+{
+    public abstract class BenchmarksBase
+    {
+        public LightningEnvironment Env { get; set; }
+        public LightningDatabase DB { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            const string Path = "TestDirectory";
+            
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, true);
+
+            Env = new LightningEnvironment(Path) {
+                MaxDatabases = 1
+            };
+            
+            Env.Open();
+
+            using var tx = Env.BeginTransaction();
+            DB = tx.OpenDatabase();
+
+            RunSetup();
+        }
+
+        public abstract void RunSetup();
+
+        [GlobalCleanup]
+        public void GlobalCleanup() 
+        {
+            DB.Dispose();
+            Env.Dispose();
+        }
+    }
+
+    [MemoryDiagnoser]
+    public class WriteBenchmarks : BenchmarksBase
+    {
+        [Params(1, 10, 100)]
+        public int BatchSize { get; set; }
+
+
+        [Params(4, 8, 64, 256)]
+        public int WriteSize { get; set; }
+
+
+        //[Params(true, false)]
+        [Params(true)]
+        public bool SequentialKeys { get; set; }
+
+        public byte[] ValueBuffer { get; set; }
+        public byte[][] KeyBuffers { get; set; }
+
+
+
+        public override void RunSetup()
+        {
+            ValueBuffer = new byte[WriteSize];
+            KeyBuffers = new byte[BatchSize][];
+
+            if(SequentialKeys) {
+                for(int i = 0; i < BatchSize; i++) {
+                    var key = new byte[4];
+                    MemoryMarshal.Write(key, ref i);
+                    KeyBuffers[i] = key;
+                }
+            }
+            else {
+                var random = new Random(0);
+                var seen = new HashSet<int>(BatchSize);
+
+                for (int i = 0; i < BatchSize;) {                    
+                    var keyValue = random.Next(0, BatchSize);
+
+                    if (seen.Add(keyValue)) {
+                        var key = new byte[4];
+                        MemoryMarshal.Write(key, ref keyValue);
+                        KeyBuffers[i++] = key;
+                    }
+                    else
+                        continue;
+                }
+            }
+        }
+
+
+        [Benchmark]
+        public void Write()
+        {
+            using(var transaction = Env.BeginTransaction())
+            {
+                for (int i = 0; i < BatchSize; i++) {
+                    transaction.Put(DB, KeyBuffers[i], ValueBuffer);
+                }
+            }
+        }
+    }
+}

--- a/src/LightningDB.Benchmarks/LightningDB.Benchmarks.csproj
+++ b/src/LightningDB.Benchmarks/LightningDB.Benchmarks.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LightningDB\LightningDB.csproj" />
+  </ItemGroup>
+
+<ItemGroup Condition=" '$(OS)' == 'Unix' ">
+  <None Include="../LightningDB/runtimes/osx/native/lmdb.dylib" CopyToOutputDirectory="PreserveNewest" />
+</ItemGroup>
+<ItemGroup Condition=" '$(Platform)' == 'x86' AND '$(OS)' != 'Unix' ">
+  <None Include="../LightningDB/runtimes/win-x86/native/lmdb.dll" CopyToOutputDirectory="PreserveNewest" />
+</ItemGroup>
+<ItemGroup Condition=" ('$(Platform)' == 'x64' OR '$(Platform)' == 'AnyCPU') AND '$(OS)' == 'Windows_NT' ">
+  <None Include="../LightningDB/runtimes/win-x64/native/lmdb.dll" CopyToOutputDirectory="PreserveNewest" />
+</ItemGroup>
+
+
+</Project>

--- a/src/LightningDB.Benchmarks/Main.cs
+++ b/src/LightningDB.Benchmarks/Main.cs
@@ -1,0 +1,13 @@
+using System;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains;
+
+namespace LightningDB.Benchmarks {
+    public static class Entry 
+    {
+        public static void Main(string[] args)
+        {
+            BenchmarkRunner.Run<WriteBenchmarks>();
+        }
+    }
+}


### PR DESCRIPTION
This PR closes #114 

I've added a working Benchmark.Net project and some very basic write performance tests.

On my machine they take several minutes to run and produced the following 


``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.836 (1909/November2018Update/19H2)
Intel Core i7-8750H CPU 2.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=5.0.100-preview.5.20279.10
  [Host]     : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT


```
| Method | BatchSize | WriteSize | SequentialKeys |      Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |---------- |---------- |--------------- |----------:|----------:|----------:|-------:|------:|------:|----------:|
|  **Write** |         **1** |         **4** |           **True** |  **1.628 μs** | **0.0220 μs** | **0.0206 μs** | **0.0629** |     **-** |     **-** |     **304 B** |
|  **Write** |         **1** |         **8** |           **True** |  **1.605 μs** | **0.0101 μs** | **0.0079 μs** | **0.0629** |     **-** |     **-** |     **304 B** |
|  **Write** |         **1** |        **64** |           **True** |  **1.602 μs** | **0.0075 μs** | **0.0058 μs** | **0.0629** |     **-** |     **-** |     **304 B** |
|  **Write** |         **1** |       **256** |           **True** |  **1.620 μs** | **0.0210 μs** | **0.0196 μs** | **0.0629** |     **-** |     **-** |     **304 B** |
|  **Write** |        **10** |         **4** |           **True** |  **2.590 μs** | **0.0098 μs** | **0.0082 μs** | **0.0610** |     **-** |     **-** |     **304 B** |
|  **Write** |        **10** |         **8** |           **True** |  **2.620 μs** | **0.0333 μs** | **0.0311 μs** | **0.0610** |     **-** |     **-** |     **304 B** |
|  **Write** |        **10** |        **64** |           **True** |  **2.605 μs** | **0.0264 μs** | **0.0220 μs** | **0.0610** |     **-** |     **-** |     **304 B** |
|  **Write** |        **10** |       **256** |           **True** |  **2.703 μs** | **0.0282 μs** | **0.0264 μs** | **0.0610** |     **-** |     **-** |     **304 B** |
|  **Write** |       **100** |         **4** |           **True** | **14.852 μs** | **0.2910 μs** | **0.5322 μs** | **0.0610** |     **-** |     **-** |     **304 B** |
|  **Write** |       **100** |         **8** |           **True** | **14.730 μs** | **0.2944 μs** | **0.7386 μs** | **0.0610** |     **-** |     **-** |     **304 B** |
|  **Write** |       **100** |        **64** |           **True** | **15.623 μs** | **0.3049 μs** | **0.4373 μs** | **0.0610** |     **-** |     **-** |     **304 B** |
|  **Write** |       **100** |       **256** |           **True** | **21.123 μs** | **0.4208 μs** | **0.5471 μs** | **0.0610** |     **-** |     **-** |     **304 B** |
