### PR TITLE
Add span overloads to API

### DIFF
--- a/src/LightningDB.Tests/CursorTests.cs
+++ b/src/LightningDB.Tests/CursorTests.cs
@@ -70,8 +70,8 @@ namespace LightningDB.Tests
             {
                 Assert.True(cur.MoveToLast());
 
-                var lastKey = UTF8.GetString(cur.Current.Key.Span.ToArray());
-                var lastValue = UTF8.GetString(cur.Current.Value.Span.ToArray());
+                var lastKey = UTF8.GetString(cur.Current.Key.CopyToNewArray());
+                var lastValue = UTF8.GetString(cur.Current.Value.CopyToNewArray());
 
                 Assert.Equal("key5", lastKey);
                 Assert.Equal("key5", lastValue);
@@ -88,8 +88,8 @@ namespace LightningDB.Tests
             {
                 cur.MoveToFirst();
 
-                var lastKey = UTF8.GetString(cur.Current.Key.Span.ToArray());
-                var lastValue = UTF8.GetString(cur.Current.Value.Span.ToArray());
+                var lastKey = UTF8.GetString(cur.Current.Key.CopyToNewArray());
+                var lastValue = UTF8.GetString(cur.Current.Value.CopyToNewArray());
 
                 Assert.Equal("key1", lastKey);
                 Assert.Equal("key1", lastValue);
@@ -108,8 +108,8 @@ namespace LightningDB.Tests
 
                 while (cur.MoveNext())
                 {
-                    var key = UTF8.GetString(cur.Current.Key.Span.ToArray());
-                    var value = UTF8.GetString(cur.Current.Value.Span.ToArray());
+                    var key = UTF8.GetString(cur.Current.Key.CopyToNewArray());
+                    var value = UTF8.GetString(cur.Current.Value.CopyToNewArray());
 
                     var name = "key" + ++i;
 
@@ -136,7 +136,7 @@ namespace LightningDB.Tests
             }
             using(var cursor = _txn.CreateCursor(_db))
             {
-                var foundDeleted = cursor.Select(x => UTF8.GetString(x.Key.Span.ToArray()))
+                var foundDeleted = cursor.Select(x => UTF8.GetString(x.Key.CopyToNewArray()))
                     .Any(x => x == "key1" || x == "key2");
                 Assert.False(foundDeleted);
             }
@@ -154,8 +154,8 @@ namespace LightningDB.Tests
                 foreach (var pair in cursor)
                 {
                     var name = "key" + ++i;
-                    Assert.Equal(name, UTF8.GetString(pair.Key.Span.ToArray()));
-                    Assert.Equal(name, UTF8.GetString(pair.Value.Span.ToArray()));
+                    Assert.Equal(name, UTF8.GetString(pair.Key.CopyToNewArray()));
+                    Assert.Equal(name, UTF8.GetString(pair.Value.CopyToNewArray()));
                 }
             }
         }
@@ -180,7 +180,7 @@ namespace LightningDB.Tests
                 }
             }
 
-            Assert.Equal(values, pairs.Select(x => x.Value.Span.ToArray()).ToArray());
+            Assert.Equal(values, pairs.Select(x => x.Value.CopyToNewArray()).ToArray());
         }
 
         [Fact]
@@ -198,8 +198,8 @@ namespace LightningDB.Tests
                 cur.MoveNext();
                 cur.GetMultiple();
                 var resultPair = cur.Current;
-                Assert.Equal("TestKey", UTF8.GetString(resultPair.Key.Span.ToArray()));
-                var result = resultPair.Value.Span.ToArray().Split(sizeof(int))
+                Assert.Equal("TestKey", UTF8.GetString(resultPair.Key.CopyToNewArray()));
+                var result = resultPair.Value.CopyToNewArray().Split(sizeof(int))
                     .Select(x => BitConverter.ToInt32(x.ToArray(), 0)).ToArray();
                 Assert.Equal(original, result);
             }
@@ -219,8 +219,8 @@ namespace LightningDB.Tests
             {
                 cur.MoveNextMultiple();
                 var resultPair = cur.Current;
-                Assert.Equal("TestKey", UTF8.GetString(resultPair.Key.Span.ToArray()));
-                var result = resultPair.Value.Span.ToArray().Split(sizeof(int))
+                Assert.Equal("TestKey", UTF8.GetString(resultPair.Key.CopyToNewArray()));
+                var result = resultPair.Value.CopyToNewArray().Split(sizeof(int))
                     .Select(x => BitConverter.ToInt32(x.ToArray(), 0)).ToArray();
                 Assert.Equal(original, result);
             }

--- a/src/LightningDB.Tests/DatabaseTests.cs
+++ b/src/LightningDB.Tests/DatabaseTests.cs
@@ -89,7 +89,7 @@ namespace LightningDB.Tests
                 using (var cursor = tx.CreateCursor(db))
                 {
                     cursor.MoveNext();
-                    Assert.Equal("customdb", UTF8.GetString(cursor.Current.Key.Span.ToArray()));
+                    Assert.Equal("customdb", UTF8.GetString(cursor.Current.Key.CopyToNewArray()));
                 }
             }
         }

--- a/src/LightningDB/EnvironmentInfo.cs
+++ b/src/LightningDB/EnvironmentInfo.cs
@@ -1,9 +1,23 @@
 namespace LightningDB
 {
+    /// <summary>
+    /// Information about the environment. 
+    /// </summary>
     public class EnvironmentInfo
     {
+        /// <summary>
+        /// ID of the last used page 
+        /// </summary>
         public int LastPageNumber { get; set; }
+
+        /// <summary>
+        /// ID of the last committed transaction  
+        /// </summary>
         public int LastTransactionId { get; set; }
+
+        /// <summary>
+        /// Size of the data memory map 
+        /// </summary>
         public int MapSize { get; set; }
     }
 }

--- a/src/LightningDB/GetResult.cs
+++ b/src/LightningDB/GetResult.cs
@@ -1,0 +1,67 @@
+﻿namespace LightningDB
+{
+    /// <summary>
+    /// The result of a get operation that uses a pre-allocated buffer
+    /// </summary>
+    public readonly struct GetResult
+    {
+        public GetResult(GetResultCode resultCode, int valueLength)
+        {
+            ResultCode = resultCode;
+            ValueLength = valueLength;
+        }
+
+        /// <summary>
+        /// A success/error code for the Get operation
+        /// </summary>
+        public GetResultCode ResultCode { get; }
+
+        /// <summary>
+        /// If the key was found, this represents the length of the value
+        /// in the database.
+        /// 
+        /// <para>
+        ///     If the key was not found, this value is 0 and has no meaning.
+        /// </para>
+        /// </summary>
+        public int ValueLength { get; }
+    }
+
+    public enum GetResultCode
+    {
+        /// <summary>
+        /// Success! The requested key was found and the value was copied to 
+        /// the provided buffer.
+        /// <para>
+        ///     GetResult.Length represents the length of the value found in
+        ///     the database. (This is also the length of data copied into
+        ///     the provided buffer.)
+        /// </para>
+        /// </summary>
+        Success,
+
+        /// <summary>
+        /// Failure. The requested key was found, but the provided buffer was
+        /// too small to contain the full value. No data has been retrived.
+        /// The Get operation should be retried with a buffer at least the 
+        /// length represented in GetResult.Length
+        /// <para>
+        ///     GetResult.Length represents the length of the value found in
+        ///     the database. (This is the minimum buffer length needed for 
+        ///     the operation to succeed)
+        /// </para>
+        /// </summary>
+        DestinationTooSmall,
+
+        /// <summary>
+        /// Failure. The requested key was not found in the database. No data has 
+        /// been retrived.
+        /// <para>
+        ///     GetResult.Length has no meaning for this result. It's value
+        ///     is set to zero.
+        /// </para>
+        /// </summary>
+        KeyNotFound
+    }
+
+}

--- a/src/LightningDB/GetResult.cs
+++ b/src/LightningDB/GetResult.cs
@@ -1,7 +1,7 @@
 ﻿namespace LightningDB
 {
     /// <summary>
-    /// The result of a get operation that uses a pre-allocated buffer
+    /// A struct describing the result of a TryGet operation
     /// </summary>
     public readonly struct GetResult
     {
@@ -27,6 +27,9 @@
         public int ValueLength { get; }
     }
 
+    /// <summary>
+    /// An enumeration describing the result of a TryGet operation
+    /// </summary>
     public enum GetResultCode
     {
         /// <summary>

--- a/src/LightningDB/LightningCursor.cs
+++ b/src/LightningDB/LightningCursor.cs
@@ -38,6 +38,9 @@ namespace LightningDB
             Transaction.Disposing += Dispose;
         }
 
+        /// <summary>
+        /// Gets the the native handle of the cursor
+        /// </summary>
         public IntPtr Handle()
         {
             return _handle;
@@ -48,6 +51,9 @@ namespace LightningDB
         /// </summary>
         public LightningTransaction Transaction { get; }
 
+        /// <summary>
+        /// Equivilent to Renew
+        /// </summary>
         public void Reset()
         {
             Renew();

--- a/src/LightningDB/LightningEnvironment.cs
+++ b/src/LightningDB/LightningEnvironment.cs
@@ -50,14 +50,19 @@ namespace LightningDB
         /// </summary>
         public LightningVersionInfo Version => LightningVersionInfo.Get();
 
-        /// Set the size of the memory map to use for this environment.
+
+        /// <summary>
+        /// Gets or Sets the size of the memory map to use for this environment.
+        /// The size of the memory map is also the maximum size of the database. 
         /// The size should be a multiple of the OS page size. 
         /// The default is 10485760 bytes. 
-        /// The size of the memory map is also the maximum size of the database. 
+        /// </summary>
+        /// <remarks>
         /// The value should be chosen as large as possible, to accommodate future growth of the database. 
-        /// This function may only be called before the environment is opened. 
-        /// The size may be changed by closing and reopening the environment. 
-        /// Any attempt to set a size smaller than the space already consumed by the environment will be silently changed to the current size of the used space.
+        /// This function may only be called before the environment is opened.
+        /// The size may be changed by closing and reopening the environment.  
+        /// Any attempt to set a size smaller than the space already consumed by the environment will be silently changed to the current size of the used space. 
+        /// </remarks>
         public long MapSize
         {
             get { return _config.MapSize; }
@@ -118,6 +123,9 @@ namespace LightningDB
             }
         }
 
+        /// <summary>
+        /// Get statistics about the LMDB environment. 
+        /// </summary>
         public Stats EnvironmentStats
         {
             get
@@ -134,7 +142,10 @@ namespace LightningDB
                 };
             }
         }
-        
+
+        /// <summary>
+        /// Gets information about the LMDB environment. 
+        /// </summary>
         public EnvironmentInfo Info
         {
             get

--- a/src/LightningDB/Native/Lmdb.cs
+++ b/src/LightningDB/Native/Lmdb.cs
@@ -265,7 +265,10 @@ namespace LightningDB.Native
             return check(LmdbMethods.mdb_cursor_put(cursor, ref key, ref value, flags));
         }
 
-
+        /// <summary>
+        /// store multiple contiguous data elements in a single request.
+        /// May only be used with MDB_DUPFIXED.
+        /// </summary>
         /// <param name="data">This span must be pinned or stackalloc memory</param>
         public unsafe static int mdb_cursor_put(IntPtr cursor, ref MDBValue key, ref Span<MDBValue> data, CursorPutOptions flags)
         {

--- a/src/LightningDB/Native/MDBEnvInfo.cs
+++ b/src/LightningDB/Native/MDBEnvInfo.cs
@@ -2,6 +2,9 @@
 
 namespace LightningDB.Native
 {
+    /// <summary>
+    /// Information about the environment. 
+    /// </summary>
     public struct MDBEnvInfo
     {
         /// <summary>

--- a/src/LightningDB/Native/MDBStat.cs
+++ b/src/LightningDB/Native/MDBStat.cs
@@ -2,6 +2,9 @@
 
 namespace LightningDB.Native
 {
+    /// <summary>
+    /// Statistics for a database in the environment. 
+    /// </summary>
     public struct MDBStat
     {
         /// <summary>

--- a/src/LightningDB/Native/MDBValue.cs
+++ b/src/LightningDB/Native/MDBValue.cs
@@ -1,24 +1,49 @@
 ﻿using System;
+using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace LightningDB.Native
 {
+    /// <summary>
+    /// A managed version of the native MDB_val type
+    /// </summary>
+    /// <remarks>
+    /// For Performance and Correctness, the layout of this struct must not be changed. 
+    /// This struct is blittable and is marshalled directly to Native code via
+    /// P/Invoke.
+    /// </remarks>
     public unsafe struct MDBValue
     {
-        internal MDBValue(Span<byte> span)
+#warning add details fixed performance vs GCHandle pinning
+        /// <remarks>
+        /// We only expose this shape constructor to basically force you to use
+        /// a fixed statment to obtain the pointer. If we accepted a Span or 
+        /// ReadOnlySpan here, we would have to do scarier things to pin/unpin
+        /// the buffer. Since this library is geared towards safe and easy usage,
+        /// this way somewhat forces you onto the correct path.
+        /// 
+        /// We could also use GCHandle.Alloc to pin
+        /// </remarks>
+        /// <param name="data">A pointer to a buffer. This buffer must be pinned or allocated from 
+        /// the stack to avoid it being moved by the GC during a collection</param>
+        internal MDBValue(int bufferSize, byte* pinnedOrStackAllocBuffer)
         {
-            size = (IntPtr) span.Length;
-            data = (byte*)Unsafe.AsPointer(ref span.GetPinnableReference());
+            this.size = (IntPtr)bufferSize;
+            this.data = pinnedOrStackAllocBuffer;
         }
-        
-        internal MDBValue(Span<byte> span, int size)
-        {
-            this.size = (IntPtr) size;
-            data = (byte*)Unsafe.AsPointer(ref span.GetPinnableReference());
-        }
-        
+
         internal IntPtr size;
         internal byte* data;
-        public ReadOnlySpan<byte> Span => new Span<byte>(data, (int)size);
+
+        public ReadOnlySpan<byte> AsSpan() => new ReadOnlySpan<byte>(data, checked((int)size));
+
+        /// <summary>
+        /// Convinence method to make intent more clear
+        /// </summary>
+        /// <returns>A newly allocated array containing data copied from the dereferenced data pointer</returns>
+        public byte[] CopyToNewArray() => AsSpan().ToArray();
+
+        public bool TryCopyTo(Span<byte> destinationBuffer) => AsSpan().TryCopyTo(destinationBuffer);
     }
 }

--- a/src/LightningDB/Stats.cs
+++ b/src/LightningDB/Stats.cs
@@ -1,12 +1,38 @@
 ﻿namespace LightningDB
 {
+    /// <summary>
+    /// Statistics for a database in the environment. 
+    /// </summary>
     public class Stats
     {
+        /// <summary>
+        /// Size of a database page. This is currently the same for all databases. 
+        /// </summary>
         public long PageSize { get; set; }
+
+        /// <summary>
+        /// Depth (height) of the B-tree 
+        /// </summary>
         public long BTreeDepth { get; set; }
+
+        /// <summary>
+        /// Number of internal (non-leaf) pages 
+        /// </summary>
         public long BranchPages { get; set; }
+
+        /// <summary>
+        /// Number of leaf pages 
+        /// </summary>
         public long LeafPages { get; set; }
+
+        /// <summary>
+        /// Number of overflow pages 
+        /// </summary>
         public long OverflowPages { get; set; }
+
+        /// <summary>
+        /// Number of data items 
+        /// </summary>
         public long Entries { get; set; }
     }
 }


### PR DESCRIPTION
This PR closes #116. It surfaces Span overloads for most operations and should improve both read and write performance primarily  by reducing GC allocations 