### PR TITLE
Optionally omit closing the database handle, causes issues in multi t…

### DIFF
--- a/src/LightningDB/LightningTransaction.cs
+++ b/src/LightningDB/LightningTransaction.cs
@@ -82,11 +82,12 @@ namespace LightningDB
         /// </summary>
         /// <param name="name">Database name (optional). If null then the default name is used.</param>
         /// <param name="configuration">Database open options.</param>
+        /// <param name="closeOnDispose">Close database handle on dispose</param>
         /// <returns>Created database wrapper.</returns>
-        public LightningDatabase OpenDatabase(string name = null, DatabaseConfiguration configuration = null)
+        public LightningDatabase OpenDatabase(string name = null, DatabaseConfiguration configuration = null, bool closeOnDispose = true)
         {
             configuration = configuration ?? new DatabaseConfiguration();
-            var db = new LightningDatabase(name, this, configuration);
+            var db = new LightningDatabase(name, this, configuration, closeOnDispose);
             return db;
         }
 


### PR DESCRIPTION
Optional behavior to omit calling mdb_dbi_close(), as it causes problems in multi threaded environments.
https://github.com/CoreyKaylor/Lightning.NET/issues/72

Also, calling mdb_dbi_close() is normally unnecessary
http://www.lmdb.tech/doc/group__mdb.html#ga52dd98d0c542378370cd6b712ff961b5