### PR TITLE
ArithmeticOverflow in EnvironmentInfo

### DIFF
--- a/src/LightningDB.Tests/EnvironmentTests.cs
+++ b/src/LightningDB.Tests/EnvironmentTests.cs
@@ -51,12 +51,14 @@ namespace LightningDB.Tests
             Assert.Throws<InvalidOperationException>(() => _env.BeginTransaction());
         }
 
-        [Fact]
-        public void CanGetEnvironmentInfo()
+        [Theory]
+        [InlineData(1024 * 1024 * 200)]
+        [InlineData(1024 * 1024 * 1024 * 3L)]
+        public void CanGetEnvironmentInfo(long mapSize)
         {
             _env = new LightningEnvironment(_path, new EnvironmentConfiguration
             {
-                MapSize = 1024 * 1024 * 200,
+                MapSize = mapSize,
             });
             _env.Open();
             var info = _env.Info;

--- a/src/LightningDB/EnvironmentInfo.cs
+++ b/src/LightningDB/EnvironmentInfo.cs
@@ -8,16 +8,16 @@ namespace LightningDB
         /// <summary>
         /// ID of the last used page 
         /// </summary>
-        public int LastPageNumber { get; set; }
+        public long LastPageNumber { get; set; }
 
         /// <summary>
         /// ID of the last committed transaction  
         /// </summary>
-        public int LastTransactionId { get; set; }
+        public long LastTransactionId { get; set; }
 
         /// <summary>
         /// Size of the data memory map 
         /// </summary>
-        public int MapSize { get; set; }
+        public long MapSize { get; set; }
     }
 }

--- a/src/LightningDB/LightningEnvironment.cs
+++ b/src/LightningDB/LightningEnvironment.cs
@@ -153,9 +153,9 @@ namespace LightningDB
                 mdb_env_info(Handle(), out var nativeInfo);
                 return new EnvironmentInfo
                 {
-                    MapSize = nativeInfo.me_mapsize.ToInt32(),
-                    LastPageNumber = nativeInfo.me_last_pgno.ToInt32(),
-                    LastTransactionId = nativeInfo.me_last_txnid.ToInt32(),
+                    MapSize = nativeInfo.me_mapsize.ToInt64(),
+                    LastPageNumber = nativeInfo.me_last_pgno.ToInt64(),
+                    LastTransactionId = nativeInfo.me_last_txnid.ToInt64(),
                 };
             }
         }


### PR DESCRIPTION
Hi!

There is arithmetic overflow in getting `EnvironmentInfo`.
One can checkout penultimate commit to get test failed.
This is reproducible on Windows.