### PR TITLE
Fix AsEnumerable silent failure

### DIFF
--- a/src/LightningDB/LightningExtensions.cs
+++ b/src/LightningDB/LightningExtensions.cs
@@ -64,14 +64,12 @@ namespace LightningDB
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static IEnumerable<ValueTuple<MDBValue, MDBValue>> AsEnumerable(this LightningCursor cursor)
         {
-            do
+            while(cursor.Next() == MDBResultCode.Success)
             {
                 var (resultCode, key, value) = cursor.GetCurrent();
-                if (resultCode == MDBResultCode.Success)
-                {
-                    yield return (key, value);
-                }
-            } while (cursor.Next() == MDBResultCode.Success);
+                resultCode.ThrowOnError();
+                yield return (key, value);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Closes #139

This also identified behavior in the implementation that missed that Next() is needed before GetCurrent is called.