### PR TITLE
net7.0 &  C# style improvements

### DIFF
--- a/src/LightningDB.Benchmarks/BenchmarkBase.cs
+++ b/src/LightningDB.Benchmarks/BenchmarkBase.cs
@@ -1,92 +1,85 @@
 ﻿using System;
-using System.Dynamic;
 using System.IO;
-
-using BenchmarkDotNet;
 using BenchmarkDotNet.Attributes;
 
-using LightningDB;
 
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+namespace LightningDB.Benchmarks;
 
-namespace LightningDB.Benchmarks
+public abstract class BenchmarksBase
 {
-    public abstract class BenchmarksBase
+    public LightningEnvironment Env { get; set; }
+    public LightningDatabase DB { get; set; }
+
+    [GlobalSetup]
+    public void GlobalSetup()
     {
-        public LightningEnvironment Env { get; set; }
-        public LightningDatabase DB { get; set; }
+        Console.WriteLine("Global Setup Begin");
 
-        [GlobalSetup]
-        public void GlobalSetup()
-        {
-            Console.WriteLine("Global Setup Begin");
-
-            const string Path = "TestDirectory";
+        const string Path = "TestDirectory";
             
-            if (Directory.Exists(Path))
-                Directory.Delete(Path, true);
+        if (Directory.Exists(Path))
+            Directory.Delete(Path, true);
 
-            Env = new LightningEnvironment(Path) {
-                MaxDatabases = 1
-            };
+        Env = new LightningEnvironment(Path) {
+            MaxDatabases = 1
+        };
             
-            Env.Open();
+        Env.Open();
 
-            using (var tx = Env.BeginTransaction()) {
-                DB = tx.OpenDatabase();
-                tx.Commit();
-            }
-
-            RunSetup();
-
-            Console.WriteLine("Global Setup End");
+        using (var tx = Env.BeginTransaction()) {
+            DB = tx.OpenDatabase();
+            tx.Commit();
         }
 
-        public abstract void RunSetup();
+        RunSetup();
 
-        [GlobalCleanup]
-        public void GlobalCleanup() 
-        {
-            Console.WriteLine("Global Cleanup Begin");
-
-            try {
-                DB.Dispose();
-                Env.Dispose();
-            }
-            catch(Exception ex) {
-                Console.WriteLine(ex.ToString());
-            }
-            Console.WriteLine("Global Cleanup End");
-        }
+        Console.WriteLine("Global Setup End");
     }
 
-    public abstract class RWBenchmarksBase : BenchmarksBase
+    public abstract void RunSetup();
+
+    [GlobalCleanup]
+    public void GlobalCleanup() 
     {
-        //***** Argument Matrix Start *****//
-        [Params(1, 100, 1000)]
-        public int OpsPerTransaction { get; set; }
+        Console.WriteLine("Global Cleanup Begin");
 
-        [Params(8, 64, 256)]
-        public int ValueSize { get; set; }
-
-        [Params(KeyOrdering.Sequential)]
-        public KeyOrdering KeyOrder { get; set; }
-
-        //***** Argument Matrix End *****//
-
-
-
-        //***** Test Values Begin *****//
-
-        protected byte[] ValueBuffer { get; private set; }
-        protected KeyBatch KeyBuffers { get; private set; }
-
-        //***** Test Values End *****//
-
-        public override void RunSetup()
-        {
-            ValueBuffer = new byte[ValueSize];
-            KeyBuffers = KeyBatch.Generate(OpsPerTransaction, KeyOrder);
+        try {
+            DB.Dispose();
+            Env.Dispose();
         }
+        catch(Exception ex) {
+            Console.WriteLine(ex.ToString());
+        }
+        Console.WriteLine("Global Cleanup End");
+    }
+}
+
+public abstract class RWBenchmarksBase : BenchmarksBase
+{
+    //***** Argument Matrix Start *****//
+    [Params(1, 100, 1000)]
+    public int OpsPerTransaction { get; set; }
+
+    [Params(8, 64, 256)]
+    public int ValueSize { get; set; }
+
+    [Params(KeyOrdering.Sequential)]
+    public KeyOrdering KeyOrder { get; set; }
+
+    //***** Argument Matrix End *****//
+
+
+
+    //***** Test Values Begin *****//
+
+    protected byte[] ValueBuffer { get; private set; }
+    protected KeyBatch KeyBuffers { get; private set; }
+
+    //***** Test Values End *****//
+
+    public override void RunSetup()
+    {
+        ValueBuffer = new byte[ValueSize];
+        KeyBuffers = KeyBatch.Generate(OpsPerTransaction, KeyOrder);
     }
 }

--- a/src/LightningDB.Benchmarks/KeyBatch.cs
+++ b/src/LightningDB.Benchmarks/KeyBatch.cs
@@ -2,80 +2,78 @@
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
-namespace LightningDB.Benchmarks
-{
+namespace LightningDB.Benchmarks;
 
-    public enum KeyOrdering
+public enum KeyOrdering
+{
+    Sequential,
+    Random
+}
+
+/// <summary>
+/// A collection of 4 byte key arrays
+/// </summary>
+public class KeyBatch
+{
+    private KeyBatch(byte[][] buffers)
     {
-        Sequential,
-        Random
+        Buffers = buffers;
     }
 
-    /// <summary>
-    /// A collection of 4 byte key arrays
-    /// </summary>
-    public class KeyBatch
+    public byte[][] Buffers { get; }
+
+
+    public int Count => Buffers.Length;
+    public ref byte[] this[int index] => ref Buffers[index];
+
+
+    public static KeyBatch Generate(int keyCount, KeyOrdering keyOrdering)
     {
-        private KeyBatch(byte[][] buffers)
-        {
-            Buffers = buffers;
+        var buffers = new byte[keyCount][];
+
+        switch (keyOrdering) {
+            case KeyOrdering.Sequential:
+                PopulateSequential(buffers);
+                break;
+
+            case KeyOrdering.Random:
+                PopulateRandom(buffers);
+                break;
+
+            default:
+                throw new ArgumentException("That isn't a valid KeyOrdering", nameof(keyOrdering));
         }
 
-        public byte[][] Buffers { get; }
+        return new KeyBatch(buffers);
+    }
 
-
-        public int Count => Buffers.Length;
-        public ref byte[] this[int index] => ref Buffers[index];
-
-
-        public static KeyBatch Generate(int keyCount, KeyOrdering keyOrdering)
-        {
-            var buffers = new byte[keyCount][];
-
-            switch (keyOrdering) {
-                case KeyOrdering.Sequential:
-                    PopulateSequential(buffers);
-                    break;
-
-                case KeyOrdering.Random:
-                    PopulateRandom(buffers);
-                    break;
-
-                default:
-                    throw new ArgumentException("That isn't a valid KeyOrdering", nameof(keyOrdering));
-            }
-
-            return new KeyBatch(buffers);
+    private static void PopulateSequential(byte[][] buffers)
+    {
+        for (var i = 0; i < buffers.Length; i++) {
+            buffers[i] = CopyToArray(i);
         }
+    }
 
-        private static void PopulateSequential(byte[][] buffers)
-        {
-            for (int i = 0; i < buffers.Length; i++) {
-                buffers[i] = CopyToArray(i);
-            }
-        }
+    private static void PopulateRandom(byte[][] buffers)
+    {
+        var random = new Random(0);
+        var seen = new HashSet<int>(buffers.Length);
 
-        private static void PopulateRandom(byte[][] buffers)
-        {
-            var random = new Random(0);
-            var seen = new HashSet<int>(buffers.Length);
+        var i = 0;
+        while (i < buffers.Length) {
+            var keyValue = random.Next(0, buffers.Length);
 
-            int i = 0;
-            while (i < buffers.Length) {
-                var keyValue = random.Next(0, buffers.Length);
-
-                if (!seen.Add(keyValue)) 
-                    continue;//skip duplicates
+            if (!seen.Add(keyValue)) 
+                continue;//skip duplicates
                 
-                buffers[i++] = CopyToArray(keyValue);
-            }
+            buffers[i++] = CopyToArray(keyValue);
         }
+    }
 
-        private static byte[] CopyToArray(int keyValue)
-        {
-            var key = new byte[4];
-            MemoryMarshal.Write(key, ref keyValue);
-            return key;
-        }
+    private static byte[] CopyToArray(int keyValue)
+    {
+        var key = new byte[4];
+        MemoryMarshal.Write(key, ref keyValue);
+        return key;
     }
 }

--- a/src/LightningDB.Benchmarks/LightningDB.Benchmarks.csproj
+++ b/src/LightningDB.Benchmarks/LightningDB.Benchmarks.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LightningDB.Benchmarks/LightningDB.Benchmarks.csproj
+++ b/src/LightningDB.Benchmarks/LightningDB.Benchmarks.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <LangVersion>11</LangVersion>
+    <LightningDBTargetRuntimeRelativePath>.\</LightningDBTargetRuntimeRelativePath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,16 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\LightningDB\LightningDB.csproj" />
   </ItemGroup>
-
-<ItemGroup Condition=" '$(OS)' == 'Unix' ">
-  <None Include="../LightningDB/runtimes/osx/native/lmdb.dylib" CopyToOutputDirectory="PreserveNewest" />
-</ItemGroup>
-<ItemGroup Condition=" '$(Platform)' == 'x86' AND '$(OS)' != 'Unix' ">
-  <None Include="../LightningDB/runtimes/win-x86/native/lmdb.dll" CopyToOutputDirectory="PreserveNewest" />
-</ItemGroup>
-<ItemGroup Condition=" ('$(Platform)' == 'x64' OR '$(Platform)' == 'AnyCPU') AND '$(OS)' == 'Windows_NT' ">
-  <None Include="../LightningDB/runtimes/win-x64/native/lmdb.dll" CopyToOutputDirectory="PreserveNewest" />
-</ItemGroup>
-
+  
+  <Import Project="..\LightningDB\LightningDB.targets" />
 
 </Project>

--- a/src/LightningDB.Benchmarks/Main.cs
+++ b/src/LightningDB.Benchmarks/Main.cs
@@ -1,13 +1,12 @@
-using System;
 using BenchmarkDotNet.Running;
 
-namespace LightningDB.Benchmarks {
-    public static class Entry 
+namespace LightningDB.Benchmarks;
+
+public static class Entry 
+{
+    public static void Main(string[] args)
     {
-        public static void Main(string[] args)
-        {
-            //BenchmarkRunner.Run<WriteBenchmarks>();
-            BenchmarkRunner.Run<ReadBenchmarks>();
-        }
+        //BenchmarkRunner.Run<WriteBenchmarks>();
+        BenchmarkRunner.Run<ReadBenchmarks>();
     }
 }

--- a/src/LightningDB.Benchmarks/ReadBenchmarks.cs
+++ b/src/LightningDB.Benchmarks/ReadBenchmarks.cs
@@ -1,31 +1,30 @@
 ﻿
 using BenchmarkDotNet.Attributes;
 
-namespace LightningDB.Benchmarks
+namespace LightningDB.Benchmarks;
+
+[MemoryDiagnoser]
+public class ReadBenchmarks : RWBenchmarksBase
 {
-    [MemoryDiagnoser]
-    public class ReadBenchmarks : RWBenchmarksBase
+    public override void RunSetup()
     {
-        public override void RunSetup()
-        {
-            base.RunSetup();
+        base.RunSetup();
 
-            //setup data to read
-            using var tx = Env.BeginTransaction();
-            for (int i = 0; i < KeyBuffers.Count; i++)
-                tx.Put(DB, KeyBuffers[i], ValueBuffer);
+        //setup data to read
+        using var tx = Env.BeginTransaction();
+        for (var i = 0; i < KeyBuffers.Count; i++)
+            tx.Put(DB, KeyBuffers[i], ValueBuffer);
 
-            tx.Commit();
-        }
+        tx.Commit();
+    }
 
-        [Benchmark]
-        public void Read()
-        {
-            using var transaction = Env.BeginTransaction(beginFlags: TransactionBeginFlags.ReadOnly);
+    [Benchmark]
+    public void Read()
+    {
+        using var transaction = Env.BeginTransaction(beginFlags: TransactionBeginFlags.ReadOnly);
 
-            for (int i = 0; i < OpsPerTransaction; i++) {
-                var _ = transaction.Get(DB, KeyBuffers[i]);
-            }
+        for (var i = 0; i < OpsPerTransaction; i++) {
+            var _ = transaction.Get(DB, KeyBuffers[i]);
         }
     }
 }

--- a/src/LightningDB.Benchmarks/WriteBenchmarks.cs
+++ b/src/LightningDB.Benchmarks/WriteBenchmarks.cs
@@ -1,24 +1,19 @@
-﻿using System.Collections;
+﻿using BenchmarkDotNet.Attributes;
 
-using BenchmarkDotNet.Attributes;
+namespace LightningDB.Benchmarks;
 
-using Microsoft.Diagnostics.Tracing.Parsers.MicrosoftWindowsTCPIP;
-
-namespace LightningDB.Benchmarks
+[MemoryDiagnoser]
+public class WriteBenchmarks : RWBenchmarksBase
 {
-    [MemoryDiagnoser]
-    public class WriteBenchmarks : RWBenchmarksBase
+    [Benchmark]
+    public void Write()
     {
-        [Benchmark]
-        public void Write()
-        {
-            using var transaction = Env.BeginTransaction();
+        using var transaction = Env.BeginTransaction();
 
-            for (int i = 0; i < OpsPerTransaction; i++) {
-                transaction.Put(DB, KeyBuffers[i], ValueBuffer);
-            }
-
-            transaction.Commit();
+        for (var i = 0; i < OpsPerTransaction; i++) {
+            transaction.Put(DB, KeyBuffers[i], ValueBuffer);
         }
+
+        transaction.Commit();
     }
 }

--- a/src/LightningDB.Tests/ConditionalFacts.cs
+++ b/src/LightningDB.Tests/ConditionalFacts.cs
@@ -9,7 +9,7 @@ public class WindowsOnlyFactAttribute : FactAttribute
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            Skip = $"Skipped for for non-Windows OS";
+            Skip = "Skipped for for non-Windows OS";
         }
     }
 }

--- a/src/LightningDB.Tests/CursorTests.cs
+++ b/src/LightningDB.Tests/CursorTests.cs
@@ -60,6 +60,8 @@ public class CursorTests : IDisposable
         _env.RunCursorScenario((tx, _, c) =>
         {
             PopulateCursorValues(c);
+            c.Dispose();
+            //TODO evaluate how not to require this Dispose likely due to #155
             var result = tx.Commit();
             Assert.Equal(MDBResultCode.Success, result);
         });

--- a/src/LightningDB.Tests/CursorTests.cs
+++ b/src/LightningDB.Tests/CursorTests.cs
@@ -3,364 +3,361 @@ using System.Linq;
 using Xunit;
 using static System.Text.Encoding;
 
-namespace LightningDB.Tests
+namespace LightningDB.Tests;
+
+[Collection("SharedFileSystem")]
+public class CursorTests : IDisposable
 {
-    [Collection("SharedFileSystem")]
-    public class CursorTests : IDisposable
+    private readonly LightningEnvironment _env;
+
+    public CursorTests(SharedFileSystem fileSystem)
     {
-        private readonly LightningEnvironment _env;
+        var path = fileSystem.CreateNewDirectoryForTest();
+        _env = new LightningEnvironment(path);
+        _env.Open();
+    }
 
-        public CursorTests(SharedFileSystem fileSystem)
+    public void Dispose()
+    {
+        _env.Dispose();
+    }
+
+    private static byte[][] PopulateCursorValues(LightningCursor cursor, int count = 5, string keyPrefix = "key")
+    {
+        var keys = Enumerable.Range(1, count)
+            .Select(i => UTF8.GetBytes(keyPrefix + i))
+            .ToArray();
+
+        foreach (var k in keys)
         {
-            var path = fileSystem.CreateNewDirectoryForTest();
-            _env = new LightningEnvironment(path);
-            _env.Open();
+            var result = cursor.Put(k, k, CursorPutOptions.None);
+            Assert.Equal(MDBResultCode.Success, result);
         }
 
-        public void Dispose()
-        {
-            _env.Dispose();
-        }
+        return keys;
+    }
 
-        private static byte[][] PopulateCursorValues(LightningCursor cursor, int count = 5, string keyPrefix = "key")
-        {
-            var keys = Enumerable.Range(1, count)
-                .Select(i => UTF8.GetBytes(keyPrefix + i))
-                .ToArray();
+    private static byte[][] PopulateMultipleCursorValues(LightningCursor cursor, string key = "TestKey")
+    {
+        var values = Enumerable.Range(1, 5).Select(BitConverter.GetBytes).ToArray();
+        var result = cursor.Put(UTF8.GetBytes(key), values);
+        Assert.Equal(MDBResultCode.Success, result);
+        var notDuplicate = values[0];
+        result = cursor.Put(notDuplicate, notDuplicate, CursorPutOptions.NoDuplicateData);
+        Assert.Equal(MDBResultCode.Success, result);
+        return values;
+    }
 
-            foreach (var k in keys)
+    [Fact]
+    public void CursorShouldBeCreated()
+    {
+        _env.RunCursorScenario((_, _, c) => Assert.NotNull(c));
+    }
+
+    [Fact]
+    public void CursorShouldPutValues()
+    {
+        _env.RunCursorScenario((tx, _, c) =>
+        {
+            PopulateCursorValues(c);
+            var result = tx.Commit();
+            Assert.Equal(MDBResultCode.Success, result);
+        });
+    }
+
+    [Fact]
+    public void CursorShouldSetSpanKey()
+    {
+        _env.RunCursorScenario((_, _, c) =>
+        {
+            var keys = PopulateCursorValues(c);
+            var firstKey = keys.First();
+            var result = c.Set(firstKey.AsSpan());
+            Assert.Equal(MDBResultCode.Success, result);
+            var current = c.GetCurrent();
+            Assert.Equal(firstKey, current.key.CopyToNewArray());
+        });
+    }
+
+    [Fact]
+    public void CursorShouldMoveToLast()
+    {
+        _env.RunCursorScenario((_, _, c) =>
+        {
+            var keys = PopulateCursorValues(c);
+            var lastKey = keys.Last();
+            var result = c.Last();
+            Assert.Equal(MDBResultCode.Success, result);
+            var current = c.GetCurrent();
+            Assert.Equal(lastKey, current.key.CopyToNewArray());
+        });
+    }
+
+    [Fact]
+    public void CursorShouldMoveToFirst()
+    {
+        _env.RunCursorScenario((_, _, c) =>
+        {
+            var keys = PopulateCursorValues(c);
+            var firstKey = keys.First();
+            var result = c.First();
+            Assert.Equal(MDBResultCode.Success, result);
+            var current = c.GetCurrent();
+            Assert.Equal(firstKey, current.key.CopyToNewArray());
+        });
+    }
+
+    [Fact]
+    public void ShouldIterateThroughCursor()
+    {
+        _env.RunCursorScenario((tx, db, c) =>
+        {
+            var keys = PopulateCursorValues(c);
+            using var c2 = tx.CreateCursor(db);
+            var items = c2.AsEnumerable().Select((x, i) => (x, i)).ToList();
+            foreach (var (x, i) in items)
             {
-                var result = cursor.Put(k, k, CursorPutOptions.None);
-                Assert.Equal(MDBResultCode.Success, result);
+                Assert.Equal(keys[i], x.Item1.CopyToNewArray());
             }
 
-            return keys;
-        }
+            Assert.Equal(keys.Length, items.Count);
+        });
+    }
 
-        private static byte[][] PopulateMultipleCursorValues(LightningCursor cursor, string key = "TestKey")
+    [Fact]
+    public void CursorShouldDeleteElements()
+    {
+        _env.RunCursorScenario((tx, db, c) =>
         {
-            var values = Enumerable.Range(1, 5).Select(BitConverter.GetBytes).ToArray();
-            var result = cursor.Put(UTF8.GetBytes(key), values);
+            var keys = PopulateCursorValues(c).Take(2).ToArray();
+            for (var i = 0; i < 2; ++i)
+            {
+                c.Next();
+                c.Delete();
+            }
+
+            using var c2 = tx.CreateCursor(db);
+            Assert.DoesNotContain(c2.AsEnumerable(), x =>
+                keys.Any(k => x.Item1.CopyToNewArray() == k));
+        });
+    }
+
+    [Fact]
+    public void ShouldPutMultiple()
+    {
+        _env.RunCursorScenario((_, _, c) => { PopulateMultipleCursorValues(c); },
+            DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create);
+    }
+
+    [Fact]
+    public void ShouldGetMultiple()
+    {
+        _env.RunCursorScenario((_, _, c) =>
+        {
+            var key = "TestKey"u8.ToArray();
+            var keys = PopulateMultipleCursorValues(c);
+            c.Set(key);
+            c.NextDuplicate();
+            var (resultCode, _, value) = c.GetMultiple();
+            Assert.Equal(MDBResultCode.Success, resultCode);
+            Assert.Equal(keys, value.CopyToNewArray().Split(sizeof(int)).ToArray());
+        }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create);
+    }
+
+    [Fact]
+    public void ShouldGetNextMultiple()
+    {
+        _env.RunCursorScenario((_, _, c) =>
+        {
+            var key = "TestKey"u8.ToArray();
+            var keys = PopulateMultipleCursorValues(c);
+            c.Set(key);
+            var (resultCode, _, value) = c.NextMultiple();
+            Assert.Equal(MDBResultCode.Success, resultCode);
+            Assert.Equal(keys, value.CopyToNewArray().Split(sizeof(int)).ToArray());
+        }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create);
+    }
+
+    [Fact]
+    public void ShouldAdvanceKeyToClosestWhenKeyNotFound()
+    {
+        _env.RunCursorScenario((_, _, c) =>
+        {
+            var expected = PopulateCursorValues(c).First();
+            var result = c.Set("key"u8.ToArray());
+            Assert.Equal(MDBResultCode.NotFound, result);
+            var (_, key, _) = c.GetCurrent();
+            Assert.Equal(expected, key.CopyToNewArray());
+        });
+    }
+
+    [Fact]
+    public void ShouldSetKeyAndGet()
+    {
+        _env.RunCursorScenario((_, _, c) =>
+        {
+            var expected = PopulateCursorValues(c).ElementAt(2);
+            var result = c.SetKey(expected);
+            Assert.Equal(MDBResultCode.Success, result.resultCode);
+            Assert.Equal(expected, result.key.CopyToNewArray());
+        }); 
+    }
+        
+    [Fact]
+    public void ShouldSetKeyAndGetWithSpan()
+    {
+        _env.RunCursorScenario((_, _, c) =>
+        {
+            var expected = PopulateCursorValues(c).ElementAt(2);
+            var result = c.SetKey(expected.AsSpan());
+            Assert.Equal(MDBResultCode.Success, result.resultCode);
+            Assert.Equal(expected, result.key.CopyToNewArray());
+        }); 
+    }
+        
+    [Fact]
+    public void ShouldGetBoth()
+    {
+        _env.RunCursorScenario((_, _, c) =>
+        {
+            var expected = PopulateCursorValues(c).ElementAt(2);
+            var result = c.GetBoth(expected, expected);
             Assert.Equal(MDBResultCode.Success, result);
-            var notDuplicate = values[0];
-            result = cursor.Put(notDuplicate, notDuplicate, CursorPutOptions.NoDuplicateData);
+        }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create); 
+    }
+        
+    [Fact]
+    public void ShouldGetBothWithSpan()
+    {
+        _env.RunCursorScenario((_, _, c) =>
+        {
+            var expected = PopulateCursorValues(c).ElementAt(2);
+            var expectedSpan = expected.AsSpan();
+            var result = c.GetBoth(expectedSpan, expectedSpan);
             Assert.Equal(MDBResultCode.Success, result);
-            return values;
-        }
-
-        [Fact]
-        public void CursorShouldBeCreated()
-        {
-            _env.RunCursorScenario((tx, db, c) => Assert.NotNull(c));
-        }
-
-        [Fact]
-        public void CursorShouldPutValues()
-        {
-            _env.RunCursorScenario((tx, db, c) =>
-            {
-                PopulateCursorValues(c);
-                c.Dispose();
-                //TODO evaluate how not to require this Dispose on Linux (test only fails there)
-                var result = tx.Commit();
-                Assert.Equal(MDBResultCode.Success, result);
-            });
-        }
-
-        [Fact]
-        public void CursorShouldSetSpanKey()
-        {
-            _env.RunCursorScenario((tx, db, c) =>
-            {
-                var keys = PopulateCursorValues(c);
-                var firstKey = keys.First();
-                var result = c.Set(firstKey.AsSpan());
-                Assert.Equal(MDBResultCode.Success, result);
-                var current = c.GetCurrent();
-                Assert.Equal(firstKey, current.key.CopyToNewArray());
-            });
-        }
-
-        [Fact]
-        public void CursorShouldMoveToLast()
-        {
-            _env.RunCursorScenario((tx, db, c) =>
-            {
-                var keys = PopulateCursorValues(c);
-                var lastKey = keys.Last();
-                var result = c.Last();
-                Assert.Equal(MDBResultCode.Success, result);
-                var current = c.GetCurrent();
-                Assert.Equal(lastKey, current.key.CopyToNewArray());
-            });
-        }
-
-        [Fact]
-        public void CursorShouldMoveToFirst()
-        {
-            _env.RunCursorScenario((tx, db, c) =>
-            {
-                var keys = PopulateCursorValues(c);
-                var firstKey = keys.First();
-                var result = c.First();
-                Assert.Equal(MDBResultCode.Success, result);
-                var current = c.GetCurrent();
-                Assert.Equal(firstKey, current.key.CopyToNewArray());
-            });
-        }
-
-        [Fact]
-        public void ShouldIterateThroughCursor()
-        {
-            _env.RunCursorScenario((tx, db, c) =>
-            {
-                var keys = PopulateCursorValues(c);
-                using var c2 = tx.CreateCursor(db);
-                var items = c2.AsEnumerable().Select((x, i) => (x, i)).ToList();
-                foreach (var (x, i) in items)
-                {
-                    Assert.Equal(keys[i], x.Item1.CopyToNewArray());
-                }
-
-                Assert.Equal(keys.Length, items.Count);
-            });
-        }
-
-        [Fact]
-        public void CursorShouldDeleteElements()
-        {
-            _env.RunCursorScenario((tx, db, c) =>
-            {
-                var keys = PopulateCursorValues(c).Take(2).ToArray();
-                for (var i = 0; i < 2; ++i)
-                {
-                    c.Next();
-                    c.Delete();
-                }
-
-                using var c2 = tx.CreateCursor(db);
-                Assert.DoesNotContain(c2.AsEnumerable(), x =>
-                    keys.Any(k => x.Item1.CopyToNewArray() == k));
-            });
-        }
-
-        [Fact]
-        public void ShouldPutMultiple()
-        {
-            _env.RunCursorScenario((tx, db, c) => { PopulateMultipleCursorValues(c); },
-                DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create);
-        }
-
-        [Fact]
-        public void ShouldGetMultiple()
-        {
-            _env.RunCursorScenario((tx, db, c) =>
-            {
-                var key = UTF8.GetBytes("TestKey");
-                var keys = PopulateMultipleCursorValues(c);
-                c.Set(key);
-                c.NextDuplicate();
-                var (resultCode, _, value) = c.GetMultiple();
-                Assert.Equal(MDBResultCode.Success, resultCode);
-                Assert.Equal(keys, value.CopyToNewArray().Split(sizeof(int)).ToArray());
-            }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create);
-        }
-
-        [Fact]
-        public void ShouldGetNextMultiple()
-        {
-            _env.RunCursorScenario((tx, db, c) =>
-            {
-                var key = UTF8.GetBytes("TestKey");
-                var keys = PopulateMultipleCursorValues(c);
-                c.Set(key);
-                var (resultCode, _, value) = c.NextMultiple();
-                Assert.Equal(MDBResultCode.Success, resultCode);
-                Assert.Equal(keys, value.CopyToNewArray().Split(sizeof(int)).ToArray());
-            }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create);
-        }
-
-        [Fact]
-        public void ShouldAdvanceKeyToClosestWhenKeyNotFound()
-        {
-            _env.RunCursorScenario((tx, db, c) =>
-            {
-                var expected = PopulateCursorValues(c).First();
-                var result = c.Set(UTF8.GetBytes("key"));
-                Assert.Equal(MDBResultCode.NotFound, result);
-                var (_, key, _) = c.GetCurrent();
-                Assert.Equal(expected, key.CopyToNewArray());
-            });
-        }
-
-        [Fact]
-        public void ShouldSetKeyAndGet()
-        {
-            _env.RunCursorScenario((tx, db, c) =>
-            {
-                var expected = PopulateCursorValues(c).ElementAt(2);
-                var result = c.SetKey(expected);
-                Assert.Equal(MDBResultCode.Success, result.resultCode);
-                Assert.Equal(expected, result.key.CopyToNewArray());
-            }); 
-        }
+        }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create); 
+    }
         
-        [Fact]
-        public void ShouldSetKeyAndGetWithSpan()
+    [Fact]
+    public void ShouldMoveToPrevious()
+    {
+        _env.RunCursorScenario((_, _, c) =>
         {
-            _env.RunCursorScenario((tx, db, c) =>
-            {
-                var expected = PopulateCursorValues(c).ElementAt(2);
-                var result = c.SetKey(expected.AsSpan());
-                Assert.Equal(MDBResultCode.Success, result.resultCode);
-                Assert.Equal(expected, result.key.CopyToNewArray());
-            }); 
-        }
+            var expected = PopulateCursorValues(c).ElementAt(2);
+            var expectedSpan = expected.AsSpan();
+            c.GetBoth(expectedSpan, expectedSpan);
+            var result = c.Previous();
+            Assert.Equal(MDBResultCode.Success, result);
+        }); 
+    }
         
-        [Fact]
-        public void ShouldGetBoth()
+    [Fact]
+    public void ShouldSetRangeWithSpan()
+    {
+        _env.RunCursorScenario((_, _, c) =>
         {
-            _env.RunCursorScenario((tx, db, c) =>
-            {
-                var expected = PopulateCursorValues(c).ElementAt(2);
-                var result = c.GetBoth(expected, expected);
-                Assert.Equal(MDBResultCode.Success, result);
-            }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create); 
-        }
+            var values = PopulateCursorValues(c);
+            var firstAfter = values[0].AsSpan();
+            var result = c.SetRange(firstAfter);
+            Assert.Equal(MDBResultCode.Success, result);
+            var current = c.GetCurrent();
+            Assert.Equal(values[0], current.value.CopyToNewArray());
+        }); 
+    }
         
-        [Fact]
-        public void ShouldGetBothWithSpan()
+    [Fact]
+    public void ShouldGetBothRange()
+    {
+        _env.RunCursorScenario((_, _, c) =>
         {
-            _env.RunCursorScenario((tx, db, c) =>
-            {
-                var expected = PopulateCursorValues(c).ElementAt(2);
-                var expectedSpan = expected.AsSpan();
-                var result = c.GetBoth(expectedSpan, expectedSpan);
-                Assert.Equal(MDBResultCode.Success, result);
-            }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create); 
-        }
+            var key = "TestKey"u8.ToArray();
+            var values = PopulateMultipleCursorValues(c);
+            var result = c.GetBothRange(key, values[1]);
+            Assert.Equal(MDBResultCode.Success, result);
+            var current = c.GetCurrent();
+            Assert.Equal(values[1], current.value.CopyToNewArray());
+        }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create); 
+    }
         
-        [Fact]
-        public void ShouldMoveToPrevious()
+    [Fact]
+    public void ShouldGetBothRangeWithSpan()
+    {
+        _env.RunCursorScenario((_, _, c) =>
         {
-            _env.RunCursorScenario((tx, db, c) =>
-            {
-                var expected = PopulateCursorValues(c).ElementAt(2);
-                var expectedSpan = expected.AsSpan();
-                c.GetBoth(expectedSpan, expectedSpan);
-                var result = c.Previous();
-                Assert.Equal(MDBResultCode.Success, result);
-            }); 
-        }
+            var key = "TestKey"u8.ToArray().AsSpan();
+            var values = PopulateMultipleCursorValues(c);
+            var result = c.GetBothRange(key, values[1].AsSpan());
+            Assert.Equal(MDBResultCode.Success, result);
+            var current = c.GetCurrent();
+            Assert.Equal(values[1], current.value.CopyToNewArray());
+        }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create); 
+    }
         
-        [Fact]
-        public void ShouldSetRangeWithSpan()
+    [Fact]
+    public void ShouldMoveToFirstDuplicate()
+    {
+        _env.RunCursorScenario((_, _, c) =>
         {
-            _env.RunCursorScenario((tx, db, c) =>
-            {
-                var values = PopulateCursorValues(c);
-                var firstAfter = values[0].AsSpan();
-                var result = c.SetRange(firstAfter);
-                Assert.Equal(MDBResultCode.Success, result);
-                var current = c.GetCurrent();
-                Assert.Equal(values[0], current.value.CopyToNewArray());
-            }); 
-        }
+            var key = "TestKey"u8.ToArray();
+            var values = PopulateMultipleCursorValues(c);
+            var result = c.GetBothRange(key, values[1]);
+            Assert.Equal(MDBResultCode.Success, result);
+            result = c.FirstDuplicate();
+            Assert.Equal(MDBResultCode.Success, result);
+            var current = c.GetCurrent();
+            Assert.Equal(values[0], current.value.CopyToNewArray());
+        }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create); 
+    }
         
-        [Fact]
-        public void ShouldGetBothRange()
+    [Fact]
+    public void ShouldMoveToLastDuplicate()
+    {
+        _env.RunCursorScenario((_, _, c) =>
         {
-            _env.RunCursorScenario((tx, db, c) =>
-            {
-                var key = UTF8.GetBytes("TestKey");
-                var values = PopulateMultipleCursorValues(c);
-                var result = c.GetBothRange(key, values[1]);
-                Assert.Equal(MDBResultCode.Success, result);
-                var current = c.GetCurrent();
-                Assert.Equal(values[1], current.value.CopyToNewArray());
-            }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create); 
-        }
+            var key = "TestKey"u8.ToArray();
+            var values = PopulateMultipleCursorValues(c);
+            c.Set(key);
+            var result = c.LastDuplicate();
+            Assert.Equal(MDBResultCode.Success, result);
+            var current = c.GetCurrent();
+            Assert.Equal(values[4], current.value.CopyToNewArray());
+        }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create); 
+    }
         
-        [Fact]
-        public void ShouldGetBothRangeWithSpan()
+    [Fact]
+    public void ShouldMoveToNextNoDuplicate()
+    {
+        _env.RunCursorScenario((_, _, c) =>
         {
-            _env.RunCursorScenario((tx, db, c) =>
-            {
-                var key = UTF8.GetBytes("TestKey").AsSpan();
-                var values = PopulateMultipleCursorValues(c);
-                var result = c.GetBothRange(key, values[1].AsSpan());
-                Assert.Equal(MDBResultCode.Success, result);
-                var current = c.GetCurrent();
-                Assert.Equal(values[1], current.value.CopyToNewArray());
-            }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create); 
-        }
+            var values = PopulateMultipleCursorValues(c);
+            var result = c.NextNoDuplicate();
+            Assert.Equal(MDBResultCode.Success, result);
+            var current = c.GetCurrent();
+            Assert.Equal(values[0], current.value.CopyToNewArray());
+        }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create); 
+    }
         
-        [Fact]
-        public void ShouldMoveToFirstDuplicate()
+    [Fact]
+    public void ShouldRenewSameTransaction()
+    {
+        _env.RunCursorScenario((_, _, c) =>
         {
-            _env.RunCursorScenario((tx, db, c) =>
-            {
-                var key = UTF8.GetBytes("TestKey");
-                var values = PopulateMultipleCursorValues(c);
-                var result = c.GetBothRange(key, values[1]);
-                Assert.Equal(MDBResultCode.Success, result);
-                result = c.FirstDuplicate();
-                Assert.Equal(MDBResultCode.Success, result);
-                var current = c.GetCurrent();
-                Assert.Equal(values[0], current.value.CopyToNewArray());
-            }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create); 
-        }
-        
-        [Fact]
-        public void ShouldMoveToLastDuplicate()
-        {
-            _env.RunCursorScenario((tx, db, c) =>
-            {
-                var key = UTF8.GetBytes("TestKey");
-                var values = PopulateMultipleCursorValues(c);
-                c.Set(key);
-                var result = c.LastDuplicate();
-                Assert.Equal(MDBResultCode.Success, result);
-                var current = c.GetCurrent();
-                Assert.Equal(values[4], current.value.CopyToNewArray());
-            }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create); 
-        }
-        
-        [Fact]
-        public void ShouldMoveToNextNoDuplicate()
-        {
-            _env.RunCursorScenario((tx, db, c) =>
-            {
-                var values = PopulateMultipleCursorValues(c);
-                var result = c.NextNoDuplicate();
-                Assert.Equal(MDBResultCode.Success, result);
-                var current = c.GetCurrent();
-                Assert.Equal(values[0], current.value.CopyToNewArray());
-            }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create); 
-        }
-        
-        [Fact]
-        public void ShouldRenewSameTransaction()
-        {
-            _env.RunCursorScenario((tx, db, c) =>
-            {
-                var result = c.Renew();
-                Assert.Equal(MDBResultCode.Success, result);
-            }, transactionFlags: TransactionBeginFlags.ReadOnly); 
-        }
+            var result = c.Renew();
+            Assert.Equal(MDBResultCode.Success, result);
+        }, transactionFlags: TransactionBeginFlags.ReadOnly); 
+    }
 
-        [Fact]
-        public void ShouldDeleteDuplicates()
+    [Fact]
+    public void ShouldDeleteDuplicates()
+    {
+        _env.RunCursorScenario((_, _, c) =>
         {
-            _env.RunCursorScenario((tx, db, c) =>
-            {
-                var key = UTF8.GetBytes("TestKey");
-                PopulateMultipleCursorValues(c);
-                c.Set(key);
-                c.DeleteDuplicateData();
-                var result = c.Set(key);
-                Assert.Equal(MDBResultCode.NotFound, result);
-            }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create);  
-        }
+            var key = "TestKey"u8.ToArray();
+            PopulateMultipleCursorValues(c);
+            c.Set(key);
+            c.DeleteDuplicateData();
+            var result = c.Set(key);
+            Assert.Equal(MDBResultCode.NotFound, result);
+        }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create);  
     }
 }

--- a/src/LightningDB.Tests/DatabaseIOTests.cs
+++ b/src/LightningDB.Tests/DatabaseIOTests.cs
@@ -1,150 +1,143 @@
 ﻿using System;
 using Xunit;
-using static System.Text.Encoding;
 
-namespace LightningDB.Tests
+namespace LightningDB.Tests;
+
+[Collection("SharedFileSystem")]
+public class DatabaseIOTests : IDisposable
 {
-    [Collection("SharedFileSystem")]
-    public class DatabaseIOTests : IDisposable
+    private readonly LightningEnvironment _env;
+    private readonly LightningTransaction _txn;
+    private readonly LightningDatabase _db;
+
+    public DatabaseIOTests(SharedFileSystem fileSystem)
     {
-        private LightningEnvironment _env;
-        private LightningTransaction _txn;
-        private LightningDatabase _db;
+        var path = fileSystem.CreateNewDirectoryForTest();
 
-        public DatabaseIOTests(SharedFileSystem fileSystem)
-        {
-            var path = fileSystem.CreateNewDirectoryForTest();
+        _env = new LightningEnvironment(path);
+        _env.MaxDatabases = 2;
+        _env.Open();
 
-            _env = new LightningEnvironment(path);
-            _env.MaxDatabases = 2;
-            _env.Open();
+        _txn = _env.BeginTransaction();
+        _db = _txn.OpenDatabase(configuration: new DatabaseConfiguration {Flags = DatabaseOpenFlags.Create});
+    }
 
-            _txn = _env.BeginTransaction();
-            _db = _txn.OpenDatabase(configuration: new DatabaseConfiguration {Flags = DatabaseOpenFlags.Create});
-        }
+    public void Dispose()
+    {
+        _env.Dispose();
+    }
 
-        public void Dispose()
-        {
-            _env.Dispose();
-        }
+    [Fact]
+    public void DatabasePutShouldNotThrowExceptions()
+    {
+        const string key = "key";
+        const string value = "value";
 
-        [Fact]
-        public void DatabasePutShouldNotThrowExceptions()
-        {
-            var key = "key";
-            var value = "value";
+        _txn.Put(_db, key, value);
+    }
 
-            _txn.Put(_db, key, value);
-        }
+    [Fact]
+    public void DatabaseGetShouldNotThrowExceptions()
+    {
+        _txn.Get(_db, "key"u8.ToArray());
+    }
 
-        [Fact]
-        public void DatabaseGetShouldNotThrowExceptions()
-        {
-            _txn.Get(_db, UTF8.GetBytes("key"));
-        }
+    [Fact]
+    public void DatabaseInsertedValueShouldBeRetrievedThen()
+    {
+        const string key = "key";
+        const string value = "value";
+        _txn.Put(_db, key, value);
 
-        [Fact]
-        public void DatabaseInsertedValueShouldBeRetrievedThen()
-        {
-            var key = "key";
-            var value = "value";
-            _txn.Put(_db, key, value);
-
-            var persistedValue = _txn.Get(_db, key);
+        var persistedValue = _txn.Get(_db, key);
             
-            Assert.Equal(persistedValue, value);
+        Assert.Equal(value, persistedValue);
+    }
+
+    [Fact]
+    public void DatabaseDeleteShouldRemoveItem()
+    {
+        const string key = "key";
+        const string value = "value";
+        _txn.Put(_db, key, value);
+
+        _txn.Delete(_db, key);
+
+        Assert.False(_txn.ContainsKey(_db, key));
+    }
+
+    [Fact]
+    public void DatabaseDeleteShouldRemoveAllDuplicateDataItems()
+    {
+        var fs = new SharedFileSystem();
+        using var env = new LightningEnvironment(fs.CreateNewDirectoryForTest(), configuration: new EnvironmentConfiguration {MapSize = 1024 * 1024, MaxDatabases = 1});
+        env.Open();
+        using var tx = env.BeginTransaction();
+        using var db = tx.OpenDatabase(configuration: new DatabaseConfiguration { Flags = DatabaseOpenFlags.DuplicatesSort});
+        const string key = "key";
+        const string value1 = "value1";
+        const string value2 = "value2";
+
+        tx.Put(db, key, value1);
+        tx.Put(db, key, value2);
+
+        tx.Delete(db, key);
+        Assert.False(tx.ContainsKey(db, key));
+    }
+
+    [Fact]
+    public void ContainsKeyShouldReturnTrueIfKeyExists()
+    {
+        const string key = "key";
+        const string value = "value";
+
+        _txn.Put(_db, key, value);
+
+        var exists = _txn.ContainsKey(_db, key);
+
+        Assert.True(exists);
+    }
+
+    [Fact]
+    public void ContainsKeyShouldReturnFalseIfKeyNotExists()
+    {
+        const string key = "key";
+
+        var exists = _txn.ContainsKey(_db, key);
+
+        Assert.False(exists);
+    }
+
+    [Fact]
+    public void TryGetShouldReturnValueIfKeyExists()
+    {
+        const string key = "key";
+        const string value = "value";
+
+        _txn.Put(_db, key, value);
+
+        var exists = _txn.TryGet(_db, key, out var persistedValue);
+
+        Assert.True(exists);
+        Assert.Equal(value, persistedValue);
+    }
+
+    [Fact]
+    public void CanCommitTransactionToNamedDatabase()
+    {
+        using (var db = _txn.OpenDatabase("test", new DatabaseConfiguration { Flags = DatabaseOpenFlags.Create }))
+        {
+            _txn.Put(db, "key1", "value");
+
+            _txn.Commit();
         }
 
-        [Fact]
-        public void DatabaseDeleteShouldRemoveItem()
+        using (var txn2 = _env.BeginTransaction())
         {
-            var key = "key";
-            var value = "value";
-            _txn.Put(_db, key, value);
-
-            _txn.Delete(_db, key);
-
-            Assert.False(_txn.ContainsKey(_db, key));
-        }
-
-        [Fact]
-        public void DatabaseDeleteShouldRemoveAllDuplicateDataItems()
-        {
-            var fs = new SharedFileSystem();
-            using (var env = new LightningEnvironment(fs.CreateNewDirectoryForTest(), configuration: new EnvironmentConfiguration {MapSize = 1024 * 1024, MaxDatabases = 1}))
+            using (var db = txn2.OpenDatabase("test"))
             {
-                env.Open();
-                using (var tx = env.BeginTransaction())
-                using (var db = tx.OpenDatabase(configuration: new DatabaseConfiguration() { Flags = DatabaseOpenFlags.DuplicatesSort}))
-                {
-                    var key = "key";
-                    var value1 = "value1";
-                    var value2 = "value2";
-
-                    tx.Put(db, key, value1);
-                    tx.Put(db, key, value2);
-
-                    tx.Delete(db, key);
-                    Assert.False(tx.ContainsKey(db, key));
-                }
-            }
-        }
-
-        [Fact]
-        public void ContainsKeyShouldReturnTrueIfKeyExists()
-        {
-            var key = "key";
-            var value = "value";
-
-            _txn.Put(_db, key, value);
-
-            var exists = _txn.ContainsKey(_db, key);
-
-            Assert.True(exists);
-        }
-
-        [Fact]
-        public void ContainsKeyShouldReturnFalseIfKeyNotExists()
-        {
-            var key = "key";
-
-            var exists = _txn.ContainsKey(_db, key);
-
-            Assert.False(exists);
-        }
-
-        [Fact]
-        public void TryGetShouldReturnValueIfKeyExists()
-        {
-            var key = "key";
-            var value = "value";
-
-            _txn.Put(_db, key, value);
-
-            string persistedValue;
-            var exists = _txn.TryGet(_db, key, out persistedValue);
-
-            Assert.True(exists);
-            Assert.Equal(value, persistedValue);
-        }
-
-        [Fact]
-        public void CanCommitTransactionToNamedDatabase()
-        {
-            using (var db = _txn.OpenDatabase("test", new DatabaseConfiguration { Flags = DatabaseOpenFlags.Create }))
-            {
-                _txn.Put(db, "key1", "value");
-
-                _txn.Commit();
-            }
-
-            using (var txn2 = _env.BeginTransaction())
-            {
-                using (var db = txn2.OpenDatabase("test"))
-                {
-                    var value = txn2.Get(db, "key1");
-                    Assert.Equal("value", value);
-                }
+                var value = txn2.Get(db, "key1");
+                Assert.Equal("value", value);
             }
         }
     }

--- a/src/LightningDB.Tests/DatabaseTests.cs
+++ b/src/LightningDB.Tests/DatabaseTests.cs
@@ -2,171 +2,170 @@
 using Xunit;
 using static System.Text.Encoding;
 
-namespace LightningDB.Tests
+namespace LightningDB.Tests;
+
+[Collection("SharedFileSystem")]
+public class DatabaseTests : IDisposable
 {
-    [Collection("SharedFileSystem")]
-    public class DatabaseTests : IDisposable
+    private readonly LightningEnvironment _env;
+    private LightningTransaction _txn;
+
+    public DatabaseTests(SharedFileSystem fileSystem)
     {
-        private LightningEnvironment _env;
-        private LightningTransaction _txn;
+        var path = fileSystem.CreateNewDirectoryForTest();
+        _env = new LightningEnvironment(path);
+    }
 
-        public DatabaseTests(SharedFileSystem fileSystem)
-        {
-            var path = fileSystem.CreateNewDirectoryForTest();
-            _env = new LightningEnvironment(path);
-        }
-
-        public void Dispose()
-        {
-            _env.Dispose();
-        }
+    public void Dispose()
+    {
+        _env.Dispose();
+    }
         
-        [Fact]
-        public void DatabaseShouldBeCreated()
+    [Fact]
+    public void DatabaseShouldBeCreated()
+    {
+        const string dbName = "test";
+        _env.MaxDatabases = 2;
+        _env.Open();
+        using (var txn = _env.BeginTransaction())
+        using (txn.OpenDatabase(dbName, new DatabaseConfiguration { Flags = DatabaseOpenFlags.Create }))
         {
-            var dbName = "test";
-            _env.MaxDatabases = 2;
-            _env.Open();
-            using (var txn = _env.BeginTransaction())
-            using (txn.OpenDatabase(dbName, new DatabaseConfiguration { Flags = DatabaseOpenFlags.Create }))
-            {
-                txn.Commit();
-            }
-            using (var txn = _env.BeginTransaction())
-            using (var db = txn.OpenDatabase(dbName, new DatabaseConfiguration { Flags = DatabaseOpenFlags.None }))
-            {
-                Assert.False(db.IsReleased);
-                txn.Commit();
-            }
+            txn.Commit();
+        }
+        using (var txn = _env.BeginTransaction())
+        using (var db = txn.OpenDatabase(dbName, new DatabaseConfiguration { Flags = DatabaseOpenFlags.None }))
+        {
+            Assert.False(db.IsReleased);
+            txn.Commit();
+        }
+    }
+
+    [Fact]
+    public void DatabaseShouldBeClosed()
+    {
+        _env.Open();
+        _txn = _env.BeginTransaction();
+        var db = _txn.OpenDatabase();
+
+        db.Dispose();
+
+        Assert.False(db.IsOpened);
+    }
+
+    [Fact]
+    public void DatabaseFromCommittedTransactionShouldBeAccessible()
+    {
+        _env.Open();
+
+        LightningDatabase db;
+        using (var committed = _env.BeginTransaction())
+        {
+            db = committed.OpenDatabase();
+            committed.Commit();
         }
 
-        [Fact]
-        public void DatabaseShouldBeClosed()
+        using (db)
+        using (var txn = _env.BeginTransaction())
         {
-            _env.Open();
-            _txn = _env.BeginTransaction();
-            var db = _txn.OpenDatabase();
-
-            db.Dispose();
-
-            Assert.False(db.IsOpened);
+            txn.Put(db, "key", 1.ToString());
+            txn.Commit();
         }
+    }
 
-        [Fact]
-        public void DatabaseFromCommitedTransactionShouldBeAccessable()
+    [Fact]
+    public void NamedDatabaseNameExistsInMaster()
+    {
+        _env.MaxDatabases = 2;
+        _env.Open();
+
+        using (var tx = _env.BeginTransaction())
         {
-            _env.Open();
-
-            LightningDatabase db;
-            using (var committed = _env.BeginTransaction())
+            tx.OpenDatabase("customdb", new DatabaseConfiguration {Flags = DatabaseOpenFlags.Create});
+            tx.Commit();
+        }
+        using (var tx = _env.BeginTransaction())
+        {
+            var db = tx.OpenDatabase();
+            using (var cursor = tx.CreateCursor(db))
             {
-                db = committed.OpenDatabase();
-                committed.Commit();
-            }
-
-            using (db)
-            using (var txn = _env.BeginTransaction())
-            {
-                txn.Put(db, "key", 1.ToString());
-                txn.Commit();
+                cursor.Next();
+                Assert.Equal("customdb", UTF8.GetString(cursor.GetCurrent().key.CopyToNewArray()));
             }
         }
+    }
 
-        [Fact]
-        public void NamedDatabaseNameExistsInMaster()
+    [Fact]
+    public void ReadonlyTransactionOpenedDatabasesDontGetReused()
+    {
+        //This is here to assert that previous issues with the way manager
+        //classes (since removed) worked don't happen anymore.
+        _env.MaxDatabases = 2;
+        _env.Open();
+
+        using (var tx = _env.BeginTransaction())
+        using (var db = tx.OpenDatabase("custom", new DatabaseConfiguration { Flags = DatabaseOpenFlags.Create }))
         {
-            _env.MaxDatabases = 2;
-            _env.Open();
-
-            using (var tx = _env.BeginTransaction())
-            {
-                var db = tx.OpenDatabase("customdb", new DatabaseConfiguration {Flags = DatabaseOpenFlags.Create});
-                tx.Commit();
-            }
-            using (var tx = _env.BeginTransaction())
-            {
-                var db = tx.OpenDatabase();
-                using (var cursor = tx.CreateCursor(db))
-                {
-                    cursor.Next();
-                    Assert.Equal("customdb", UTF8.GetString(cursor.GetCurrent().key.CopyToNewArray()));
-                }
-            }
+            tx.Put(db, "hello", "world");
+            tx.Commit();
         }
-
-        [Fact]
-        public void ReadonlyTransactionOpenedDatabasesDontGetReused()
+        using (var tx = _env.BeginTransaction(TransactionBeginFlags.ReadOnly))
         {
-            //This is here to assert that previous issues with the way manager
-            //classes (since removed) worked don't happen anymore.
-            _env.MaxDatabases = 2;
-            _env.Open();
-
-            using (var tx = _env.BeginTransaction())
-            using (var db = tx.OpenDatabase("custom", new DatabaseConfiguration { Flags = DatabaseOpenFlags.Create }))
-            {
-                tx.Put(db, "hello", "world");
-                tx.Commit();
-            }
-            using (var tx = _env.BeginTransaction(TransactionBeginFlags.ReadOnly))
-            {
-                var db = tx.OpenDatabase("custom");
-                var result = tx.Get(db, "hello");
-                Assert.Equal("world", result);
-            }
-            using (var tx = _env.BeginTransaction(TransactionBeginFlags.ReadOnly))
-            {
-                var db = tx.OpenDatabase("custom");
-                var result = tx.Get(db, "hello");
-                Assert.Equal("world", result);
-            }
+            var db = tx.OpenDatabase("custom");
+            var result = tx.Get(db, "hello");
+            Assert.Equal("world", result);
         }
-
-        [Fact]
-        public void DatabaseShouldBeDropped()
+        using (var tx = _env.BeginTransaction(TransactionBeginFlags.ReadOnly))
         {
-            _env.MaxDatabases = 2;
-            _env.Open();
-            _txn = _env.BeginTransaction();
-            var db = _txn.OpenDatabase("notmaster", new DatabaseConfiguration {Flags = DatabaseOpenFlags.Create});
-            _txn.Commit();
-            _txn.Dispose();
-            db.Dispose();
-
-            _txn = _env.BeginTransaction();
-            db = _txn.OpenDatabase("notmaster");
-
-            db.Drop(_txn);
-            _txn.Commit();
-            _txn.Dispose();
-
-            _txn = _env.BeginTransaction();
-
-            var ex = Assert.Throws<LightningException>(() => _txn.OpenDatabase("notmaster"));
-
-            Assert.Equal(-30798, ex.StatusCode);
+            var db = tx.OpenDatabase("custom");
+            var result = tx.Get(db, "hello");
+            Assert.Equal("world", result);
         }
+    }
 
-        [Fact]
-        public void TruncatingTheDatabase()
-        {
-            _env.Open();
-            _txn = _env.BeginTransaction();
-            var db = _txn.OpenDatabase();
+    [Fact]
+    public void DatabaseShouldBeDropped()
+    {
+        _env.MaxDatabases = 2;
+        _env.Open();
+        _txn = _env.BeginTransaction();
+        var db = _txn.OpenDatabase("notmaster", new DatabaseConfiguration {Flags = DatabaseOpenFlags.Create});
+        _txn.Commit();
+        _txn.Dispose();
+        db.Dispose();
 
-            _txn.Put(db, "hello", "world");
-            _txn.Commit();
-            _txn.Dispose();
-            _txn = _env.BeginTransaction();
-            db = _txn.OpenDatabase();
-            db.Truncate(_txn);
-            _txn.Commit();
-            _txn.Dispose();
-            _txn = _env.BeginTransaction();
-            db = _txn.OpenDatabase();
-            var result = _txn.Get(db, UTF8.GetBytes("hello"));
+        _txn = _env.BeginTransaction();
+        db = _txn.OpenDatabase("notmaster");
 
-            Assert.Equal(MDBResultCode.NotFound, result.resultCode);
-        }
+        db.Drop(_txn);
+        _txn.Commit();
+        _txn.Dispose();
+
+        _txn = _env.BeginTransaction();
+
+        var ex = Assert.Throws<LightningException>(() => _txn.OpenDatabase("notmaster"));
+
+        Assert.Equal(-30798, ex.StatusCode);
+    }
+
+    [Fact]
+    public void TruncatingTheDatabase()
+    {
+        _env.Open();
+        _txn = _env.BeginTransaction();
+        var db = _txn.OpenDatabase();
+
+        _txn.Put(db, "hello", "world");
+        _txn.Commit();
+        _txn.Dispose();
+        _txn = _env.BeginTransaction();
+        db = _txn.OpenDatabase();
+        db.Truncate(_txn);
+        _txn.Commit();
+        _txn.Dispose();
+        _txn = _env.BeginTransaction();
+        db = _txn.OpenDatabase();
+        var result = _txn.Get(db, "hello"u8.ToArray());
+
+        Assert.Equal(MDBResultCode.NotFound, result.resultCode);
     }
 }

--- a/src/LightningDB.Tests/EnvironmentTests.cs
+++ b/src/LightningDB.Tests/EnvironmentTests.cs
@@ -1,189 +1,185 @@
 ﻿using System;
 using System.IO;
-using System.Runtime.InteropServices;
 using Xunit;
 
-namespace LightningDB.Tests
+namespace LightningDB.Tests;
+
+[Collection("SharedFileSystem")]
+public class EnvironmentTests : IDisposable
 {
-    [Collection("SharedFileSystem")]
-    public class EnvironmentTests : IDisposable
+    private readonly string _path,  _pathCopy;
+    private LightningEnvironment _env;
+
+    public EnvironmentTests(SharedFileSystem fileSystem)
     {
-        private string _path,  _pathCopy;
-        private LightningEnvironment _env;
+        _path = fileSystem.CreateNewDirectoryForTest();
+        _pathCopy = fileSystem.CreateNewDirectoryForTest();
+    }
 
-        public EnvironmentTests(SharedFileSystem fileSystem)
+    public void Dispose()
+    {
+        _env?.Dispose();
+        _env = null;
+    }
+
+    [Fact]
+    public void EnvironmentShouldBeCreatedIfWithoutFlags()
+    {
+        _env = new LightningEnvironment(_path);
+        _env.Open();
+    }
+
+    [Fact]
+    public void EnvironmentCreatedFromConfig()
+    {
+        const int mapExpected = 1024*1024*20;
+        const int maxDatabaseExpected = 2;
+        const int maxReadersExpected = 3;
+        var config = new EnvironmentConfiguration {MapSize = mapExpected, MaxDatabases = maxDatabaseExpected, MaxReaders = maxReadersExpected};
+        _env = new LightningEnvironment(_path, config);
+        Assert.Equal(mapExpected, _env.MapSize);
+        Assert.Equal(maxDatabaseExpected, _env.MaxDatabases);
+        Assert.Equal(maxReadersExpected, _env.MaxReaders);
+    }
+
+    [Fact]
+    public void StartingTransactionBeforeEnvironmentOpen()
+    {
+        _env = new LightningEnvironment(_path);
+        Assert.Throws<InvalidOperationException>(() => _env.BeginTransaction());
+    }
+
+    [Fact]
+    public void CanGetEnvironmentInfo()
+    {
+        const long mapSize = 1024 * 1024 * 200;
+        _env = new LightningEnvironment(_path, new EnvironmentConfiguration
         {
-            _path = fileSystem.CreateNewDirectoryForTest();
-            _pathCopy = fileSystem.CreateNewDirectoryForTest();
-        }
+            MapSize = mapSize
+        });
+        _env.Open();
+        var info = _env.Info;
+        Assert.Equal(_env.MapSize, info.MapSize);
+    }
 
-        public void Dispose()
+    [Not32BitFact]
+    public void CanGetLargeEnvironmentInfo()
+    {
+        const long mapSize = 1024 * 1024 * 1024 * 3L;
+        _env = new LightningEnvironment(_path, new EnvironmentConfiguration
         {
-            if (_env != null)
-                _env.Dispose();
+            MapSize = mapSize
+        });
+        _env.Open();
+        var info = _env.Info;
+        Assert.Equal(_env.MapSize, info.MapSize);
+    }
 
-            _env = null;
-        }
-
-        [Fact]
-        public void EnvironmentShouldBeCreatedIfWithoutFlags()
+    [Fact]
+    public void MaxDatabasesWorksThroughConfigIssue62()
+    {
+        var config = new EnvironmentConfiguration { MaxDatabases = 2 };
+        _env = new LightningEnvironment(_path, config);
+        _env.Open();
+        using (var tx = _env.BeginTransaction())
         {
-            _env = new LightningEnvironment(_path);
-            _env.Open();
+            tx.OpenDatabase("db1", new DatabaseConfiguration {Flags = DatabaseOpenFlags.Create});
+            tx.OpenDatabase("db2", new DatabaseConfiguration {Flags = DatabaseOpenFlags.Create});
+            tx.Commit();
         }
+        Assert.Equal(2, _env.MaxDatabases);
+    }
 
-        [Fact]
-        public void EnvironmentCreatedFromConfig()
+    [Fact]
+    public void CanLoadAndDisposeMultipleEnvironments()
+    {
+        _env = new LightningEnvironment(_path);
+        _env.Dispose();
+        _env = new LightningEnvironment(_path);
+    }
+
+    [Fact]
+    public void EnvironmentShouldBeCreatedIfReadOnly()
+    {
+        _env = new LightningEnvironment(_path);
+        _env.Open(); //readonly requires environment to have been created at least once before
+        _env.Dispose();
+        _env = new LightningEnvironment(_path);
+        _env.Open(EnvironmentOpenFlags.ReadOnly);
+    }
+
+    [Fact]
+    public void EnvironmentShouldBeOpened()
+    {
+        _env = new LightningEnvironment(_path);
+        _env.Open();
+
+        Assert.True(_env.IsOpened);
+    }
+
+    [Fact]
+    public void EnvironmentShouldBeClosed()
+    {
+        _env = new LightningEnvironment(_path);
+        _env.Open();
+
+        _env.Dispose();
+
+        Assert.False(_env.IsOpened);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void EnvironmentShouldBeCopied(bool compact)
+    {
+        _env = new LightningEnvironment(_path);
+        _env.Open(); 
+
+        _env.CopyTo(_pathCopy, compact);
+
+        if (Directory.GetFiles(_pathCopy).Length == 0)
+            Assert.True(false, "Copied files doesn't exist");
+    }
+
+    [Fact]
+    public void CanOpenEnvironmentMoreThan50Mb()
+    {
+        _env = new LightningEnvironment(_path)
         {
-            var mapExpected = 1024*1024*20;
-            var maxDatabaseExpected = 2;
-            var maxReadersExpected = 3;
-            var config = new EnvironmentConfiguration {MapSize = mapExpected, MaxDatabases = maxDatabaseExpected, MaxReaders = maxReadersExpected};
-            _env = new LightningEnvironment(_path, config);
-            Assert.Equal(_env.MapSize, mapExpected);
-            Assert.Equal(_env.MaxDatabases, maxDatabaseExpected);
-            Assert.Equal(_env.MaxReaders, maxReadersExpected);
-        }
+            MapSize = 55 * 1024 * 1024
+        };
 
-        [Fact]
-        public void StartingTransactionBeforeEnvironmentOpen()
-        {
-            _env = new LightningEnvironment(_path);
-            Assert.Throws<InvalidOperationException>(() => _env.BeginTransaction());
-        }
-
-        [Fact]
-        public void CanGetEnvironmentInfo()
-        {
-            long mapSize = 1024 * 1024 * 200;
-            _env = new LightningEnvironment(_path, new EnvironmentConfiguration
-            {
-                MapSize = mapSize,
-            });
-            _env.Open();
-            var info = _env.Info;
-            Assert.Equal(_env.MapSize, info.MapSize);
-        }
-
-        [Not32BitFact]
-        public void CanGetLargeEnvironmentInfo()
-        {
-            long mapSize = 1024 * 1024 * 1024 * 3L;
-            _env = new LightningEnvironment(_path, new EnvironmentConfiguration
-            {
-                MapSize = mapSize,
-            });
-            _env.Open();
-            var info = _env.Info;
-            Assert.Equal(_env.MapSize, info.MapSize);
-        }
-
-        [Fact]
-        public void MaxDatabasesWorksThroughConfigIssue62()
-        {
-            var config = new EnvironmentConfiguration { MaxDatabases = 2 };
-            _env = new LightningEnvironment(_path, config);
-            _env.Open();
-            using (var tx = _env.BeginTransaction())
-            {
-                tx.OpenDatabase("db1", new DatabaseConfiguration {Flags = DatabaseOpenFlags.Create});
-                tx.OpenDatabase("db2", new DatabaseConfiguration {Flags = DatabaseOpenFlags.Create});
-                tx.Commit();
-            }
-            Assert.Equal(2, _env.MaxDatabases);
-        }
-
-        [Fact]
-        public void CanLoadAndDisposeMultipleEnvironments()
-        {
-            _env = new LightningEnvironment(_path);
-            _env.Dispose();
-            _env = new LightningEnvironment(_path);
-        }
-
-        [Fact]
-        public void EnvironmentShouldBeCreatedIfReadOnly()
-        {
-            _env = new LightningEnvironment(_path);
-            _env.Open(); //readonly requires environment to have been created at least once before
-            _env.Dispose();
-            _env = new LightningEnvironment(_path);
-            _env.Open(EnvironmentOpenFlags.ReadOnly);
-        }
-
-        [Fact]
-        public void EnvironmentShouldBeOpened()
-        {
-            _env = new LightningEnvironment(_path);
-            _env.Open();
-
-            Assert.True(_env.IsOpened);
-        }
-
-        [Fact]
-        public void EnvironmentShouldBeClosed()
-        {
-            _env = new LightningEnvironment(_path);
-            _env.Open();
-
-            _env.Dispose();
-
-            Assert.False(_env.IsOpened);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void EnvironmentShouldBeCopied(bool compact)
-        {
-            _env = new LightningEnvironment(_path);
-            _env.Open(); 
-
-            _env.CopyTo(_pathCopy, compact);
-
-            if (Directory.GetFiles(_pathCopy).Length == 0)
-                Assert.True(false, "Copied files doesn't exist");
-        }
-
-        [Fact]
-        public void CanOpenEnvironmentMoreThan50Mb()
-        {
-            _env = new LightningEnvironment(_path)
-            {
-                MapSize = 55 * 1024 * 1024
-            };
-
-            _env.Open();
-        }
+        _env.Open();
+    }
         
         
 #if NETCOREAPP3_1_OR_GREATER
-        [WindowsOnlyFact]
-        public void CreateEnvironmentWithAutoResize()
+    [WindowsOnlyFact]
+    public void CreateEnvironmentWithAutoResize()
+    {
+        using (var env = new LightningEnvironment(_path, new EnvironmentConfiguration
+               {
+                   MapSize = 1048576,
+                   AutoResizeWindows = true
+               }))
         {
-            using (var env = new LightningEnvironment(_path, new EnvironmentConfiguration
-                   {
-                       MapSize = 1048576,
-                       AutoResizeWindows = true,
-                   }))
-            {
-                env.Open();
-            }
-
-            using (var env = new LightningEnvironment(_path, new EnvironmentConfiguration
-                   {
-                       MapSize = 1048576,
-                       AutoResizeWindows = true,
-                   }))
-            {
-                env.Open();
-            }
-
-            using (var dbFile = File.OpenRead(Path.Combine(_path, "data.mdb")))
-            {
-                Assert.Equal(8192, dbFile.Length);
-            }
+            env.Open();
         }
-#endif
+
+        using (var env = new LightningEnvironment(_path, new EnvironmentConfiguration
+               {
+                   MapSize = 1048576,
+                   AutoResizeWindows = true
+               }))
+        {
+            env.Open();
+        }
+
+        using (var dbFile = File.OpenRead(Path.Combine(_path, "data.mdb")))
+        {
+            Assert.Equal(8192, dbFile.Length);
+        }
     }
+#endif
 }

--- a/src/LightningDB.Tests/LightningDB.Tests.csproj
+++ b/src/LightningDB.Tests/LightningDB.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <LangVersion>11</LangVersion>
     <AssemblyName>LightningDB.Tests</AssemblyName>
     <PackageId>LightningDB.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/src/LightningDB.Tests/LightningDB.Tests.csproj
+++ b/src/LightningDB.Tests/LightningDB.Tests.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\LightningDB\LightningDB.csproj" />
+    <ProjectReference Include="..\SecondProcess\SecondProcess.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LightningDB.Tests/MultiProcessTests.cs
+++ b/src/LightningDB.Tests/MultiProcessTests.cs
@@ -1,58 +1,55 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Text;
 using Xunit;
 
-namespace LightningDB.Tests
+namespace LightningDB.Tests;
+
+[Collection("SharedFileSystem")]
+public class MultiProcessTests 
 {
-    [Collection("SharedFileSystem")]
-    public class MultiProcessTests 
+    private readonly SharedFileSystem _fileSystem;
+
+    public MultiProcessTests(SharedFileSystem fileSystem)
     {
-        private readonly SharedFileSystem _fileSystem;
-
-        public MultiProcessTests(SharedFileSystem fileSystem)
-        {
-            _fileSystem = fileSystem;
-        }
-
-        [Fact]
-        public void can_load_environment_from_multiple_processes()
-        {
-            var name = _fileSystem.CreateNewDirectoryForTest();
-            using var env = new LightningEnvironment(name);
-            env.Open();
-            var otherProcessPath = Path.GetFullPath("../../../../SecondProcess/bin/Debug/net7.0/SecondProcess.dll");
-            using var process = new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "dotnet",
-                    Arguments = $"{otherProcessPath} {name}",
-                    RedirectStandardError = true,
-                    RedirectStandardInput = true,
-                    RedirectStandardOutput = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true,
-                    WorkingDirectory = Directory.GetCurrentDirectory()
-                }
-            };
-
-            var expected = "world";
-            using var tx = env.BeginTransaction();
-            using var db = tx.OpenDatabase();
-            tx.Put(db, Encoding.UTF8.GetBytes("hello"), Encoding.UTF8.GetBytes(expected));
-            tx.Commit();
-            
-            var current = Process.GetCurrentProcess();
-            process.Start();
-            Assert.NotEqual(current.Id, process.Id);
-            
-            var result = process.StandardOutput.ReadLine();
-            process.WaitForExit();
-            Assert.Equal(expected, result);
-        }
-
+        _fileSystem = fileSystem;
     }
+
+    [Fact]
+    public void can_load_environment_from_multiple_processes()
+    {
+        var name = _fileSystem.CreateNewDirectoryForTest();
+        using var env = new LightningEnvironment(name);
+        env.Open();
+        var otherProcessPath = Path.GetFullPath("../../../../SecondProcess/bin/Debug/net7.0/SecondProcess.dll");
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = $"{otherProcessPath} {name}",
+                RedirectStandardError = true,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WorkingDirectory = Directory.GetCurrentDirectory()
+            }
+        };
+
+        const string expected = "world";
+        using var tx = env.BeginTransaction();
+        using var db = tx.OpenDatabase();
+        tx.Put(db, "hello"u8.ToArray(), Encoding.UTF8.GetBytes(expected));
+        tx.Commit();
+            
+        var current = Process.GetCurrentProcess();
+        process.Start();
+        Assert.NotEqual(current.Id, process.Id);
+            
+        var result = process.StandardOutput.ReadLine();
+        process.WaitForExit();
+        Assert.Equal(expected, result);
+    }
+
 }

--- a/src/LightningDB.Tests/MultiProcessTests.cs
+++ b/src/LightningDB.Tests/MultiProcessTests.cs
@@ -17,13 +17,13 @@ namespace LightningDB.Tests
             _fileSystem = fileSystem;
         }
 
-        [Fact(Skip = "Hangs on Linux only for some reason")]
+        [Fact]
         public void can_load_environment_from_multiple_processes()
         {
             var name = _fileSystem.CreateNewDirectoryForTest();
             using var env = new LightningEnvironment(name);
             env.Open();
-            var otherProcessPath = Path.GetFullPath("../../../../SecondProcess/bin/Debug/netcoreapp3.0/SecondProcess.dll");
+            var otherProcessPath = Path.GetFullPath("../../../../SecondProcess/bin/Debug/net7.0/SecondProcess.dll");
             using var process = new Process
             {
                 StartInfo = new ProcessStartInfo

--- a/src/LightningDB.Tests/MultiProcessTests.cs
+++ b/src/LightningDB.Tests/MultiProcessTests.cs
@@ -21,7 +21,7 @@ public class MultiProcessTests
         var name = _fileSystem.CreateNewDirectoryForTest();
         using var env = new LightningEnvironment(name);
         env.Open();
-        var otherProcessPath = Path.GetFullPath("../../../../SecondProcess/bin/Debug/net7.0/SecondProcess.dll");
+        var otherProcessPath = Path.GetFullPath("SecondProcess.dll");
         using var process = new Process
         {
             StartInfo = new ProcessStartInfo

--- a/src/LightningDB.Tests/SharedFileSystem.cs
+++ b/src/LightningDB.Tests/SharedFileSystem.cs
@@ -2,35 +2,34 @@
 using System.IO;
 using Xunit;
 
-namespace LightningDB.Tests
+namespace LightningDB.Tests;
+
+public class SharedFileSystem : IDisposable
 {
-    public class SharedFileSystem : IDisposable
+    private readonly string _testTempDir;
+
+    public SharedFileSystem()
     {
-        private readonly string _testTempDir;
+        _testTempDir = Path.Combine(Path.GetTempPath(), "ldbtest");
+    }
 
-        public SharedFileSystem()
+    public void Dispose()
+    {
+        if (Directory.Exists(_testTempDir))
         {
-            _testTempDir = Path.Combine(Path.GetTempPath(), "ldbtest");
-        }
-
-        public void Dispose()
-        {
-            if (Directory.Exists(_testTempDir))
-            {
-                Directory.Delete(_testTempDir, true);
-            }
-        }
-
-        public string CreateNewDirectoryForTest()
-        {
-            var path = Path.Combine(_testTempDir, "TestDb", Guid.NewGuid().ToString());
-            Directory.CreateDirectory(path);
-            return path;
+            Directory.Delete(_testTempDir, true);
         }
     }
 
-    [CollectionDefinition("SharedFileSystem")]
-    public class SharedFileSystemCollection : ICollectionFixture<SharedFileSystem>
+    public string CreateNewDirectoryForTest()
     {
+        var path = Path.Combine(_testTempDir, "TestDb", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(path);
+        return path;
     }
+}
+
+[CollectionDefinition("SharedFileSystem")]
+public class SharedFileSystemCollection : ICollectionFixture<SharedFileSystem>
+{
 }

--- a/src/LightningDB.Tests/TestHelperExtensions.cs
+++ b/src/LightningDB.Tests/TestHelperExtensions.cs
@@ -2,69 +2,67 @@
 using System.Linq;
 using System.Collections.Generic;
 
-namespace LightningDB.Tests
+namespace LightningDB.Tests;
+
+public static class TestHelperExtensions
 {
-    public static class TestHelperExtensions
+    public static MDBResultCode Put(this LightningTransaction tx, LightningDatabase db, string key, string value)
     {
-        public static MDBResultCode Put(this LightningTransaction tx, LightningDatabase db, string key, string value)
-        {
-            var enc = System.Text.Encoding.UTF8;
-            return tx.Put(db, enc.GetBytes(key), enc.GetBytes(value));
-        }
+        var enc = System.Text.Encoding.UTF8;
+        return tx.Put(db, enc.GetBytes(key), enc.GetBytes(value));
+    }
 
-        public static string Get(this LightningTransaction tx, LightningDatabase db, string key)
-        {
-            var enc = System.Text.Encoding.UTF8;
-            var result = tx.Get(db, enc.GetBytes(key));
-            return enc.GetString(result.value.CopyToNewArray());
-        }
+    public static string Get(this LightningTransaction tx, LightningDatabase db, string key)
+    {
+        var enc = System.Text.Encoding.UTF8;
+        var result = tx.Get(db, enc.GetBytes(key));
+        return enc.GetString(result.value.CopyToNewArray());
+    }
 
-        public static void Delete(this LightningTransaction tx, LightningDatabase db, string key)
-        {
-            var enc = System.Text.Encoding.UTF8;
-            tx.Delete(db, enc.GetBytes(key));
-        }
+    public static void Delete(this LightningTransaction tx, LightningDatabase db, string key)
+    {
+        var enc = System.Text.Encoding.UTF8;
+        tx.Delete(db, enc.GetBytes(key));
+    }
 
-        public static bool ContainsKey(this LightningTransaction tx, LightningDatabase db, string key)
-        {
-            var enc = System.Text.Encoding.UTF8;
-            return tx.ContainsKey(db, enc.GetBytes(key));
-        }
+    public static bool ContainsKey(this LightningTransaction tx, LightningDatabase db, string key)
+    {
+        var enc = System.Text.Encoding.UTF8;
+        return tx.ContainsKey(db, enc.GetBytes(key));
+    }
 
-        public static bool TryGet(this LightningTransaction tx, LightningDatabase db, string key, out string value)
-        {
-            var enc = System.Text.Encoding.UTF8;
-            byte[] result;
-            var found = tx.TryGet(db, enc.GetBytes(key), out result);
-            value = enc.GetString(result);
-            return found;
-        }
+    public static bool TryGet(this LightningTransaction tx, LightningDatabase db, string key, out string value)
+    {
+        var enc = System.Text.Encoding.UTF8;
+        var found = tx.TryGet(db, enc.GetBytes(key), out var result);
+        value = enc.GetString(result);
+        return found;
+    }
 
-        public static IEnumerable<IEnumerable<T>> Split<T>(this IEnumerable<T> list, int parts)
-        {
-            return list
-                .Select((x, i) => new {Index = i, Value = x})
-                .GroupBy(x => x.Index / parts)
-                .Select(x => x.Select(v => v.Value));
-        }
+    public static IEnumerable<IEnumerable<T>> Split<T>(this IEnumerable<T> list, int parts)
+    {
+        return list
+            .Select((x, i) => new {Index = i, Value = x})
+            .GroupBy(x => x.Index / parts)
+            .Select(x => x.Select(v => v.Value));
+    }
 
-        public static void RunCursorScenario(this LightningEnvironment env, 
-            Action<LightningTransaction, LightningDatabase, LightningCursor> scenario,
-            DatabaseOpenFlags flags = DatabaseOpenFlags.Create, TransactionBeginFlags transactionFlags = TransactionBeginFlags.None)
-        {
-            using var tx = env.BeginTransaction(transactionFlags);
-            using var db = tx.OpenDatabase(configuration: new DatabaseConfiguration { Flags = flags });
-            using var cursor = tx.CreateCursor(db);
-            scenario(tx, db, cursor);
-        }
+    public static void RunCursorScenario(this LightningEnvironment env, 
+        Action<LightningTransaction, LightningDatabase, LightningCursor> scenario,
+        DatabaseOpenFlags flags = DatabaseOpenFlags.Create, TransactionBeginFlags transactionFlags = TransactionBeginFlags.None)
+    {
+        using var tx = env.BeginTransaction(transactionFlags);
+        using var db = tx.OpenDatabase(configuration: new DatabaseConfiguration { Flags = flags });
+        using var cursor = tx.CreateCursor(db);
+        scenario(tx, db, cursor);
+    }
         
-        public static void RunTransactionScenario(this LightningEnvironment env, 
-            Action<LightningTransaction, LightningDatabase> scenario,
-            DatabaseOpenFlags flags = DatabaseOpenFlags.Create, TransactionBeginFlags transactionFlags = TransactionBeginFlags.None)
-        {
-            using var tx = env.BeginTransaction(transactionFlags);
-            using var db = tx.OpenDatabase(configuration: new DatabaseConfiguration { Flags = flags });
-            scenario(tx, db);
-        }
+    public static void RunTransactionScenario(this LightningEnvironment env, 
+        Action<LightningTransaction, LightningDatabase> scenario,
+        DatabaseOpenFlags flags = DatabaseOpenFlags.Create, TransactionBeginFlags transactionFlags = TransactionBeginFlags.None)
+    {
+        using var tx = env.BeginTransaction(transactionFlags);
+        using var db = tx.OpenDatabase(configuration: new DatabaseConfiguration { Flags = flags });
+        scenario(tx, db);
     }
 }

--- a/src/LightningDB.Tests/TransactionTests.cs
+++ b/src/LightningDB.Tests/TransactionTests.cs
@@ -4,223 +4,221 @@ using System.Collections.Generic;
 using Xunit;
 using System.Runtime.InteropServices;
 
-namespace LightningDB.Tests
+namespace LightningDB.Tests;
+
+[Collection("SharedFileSystem")]
+public class TransactionTests : IDisposable
 {
-    [Collection("SharedFileSystem")]
-    public class TransactionTests : IDisposable
+    private readonly LightningEnvironment _env;
+
+    public TransactionTests(SharedFileSystem fileSystem)
     {
-        private readonly LightningEnvironment _env;
+        var path = fileSystem.CreateNewDirectoryForTest();
+        _env = new LightningEnvironment(path);
+        _env.Open();
+    }
 
-        public TransactionTests(SharedFileSystem fileSystem)
+    public void Dispose()
+    {
+        _env.Dispose();
+    }
+        
+    [Fact]
+    public void CanDeletePreviouslyCommittedWithMultipleValuesByPassingNullForValue()
+    {
+        _env.RunTransactionScenario((tx, db) =>
         {
-            var path = fileSystem.CreateNewDirectoryForTest();
-            _env = new LightningEnvironment(path);
-            _env.Open();
-        }
+            var key = MemoryMarshal.Cast<char, byte>("abcd");
 
-        public void Dispose()
+            tx.Put(db, key, MemoryMarshal.Cast<char, byte>("Value1"));
+            tx.Put(db, key, MemoryMarshal.Cast<char, byte>("Value2"), PutOptions.AppendData);
+            tx.Commit();
+            tx.Dispose();
+                
+            using var delTxn = _env.BeginTransaction();
+            var result = delTxn.Delete(db, key, null);
+            Assert.Equal(MDBResultCode.Success, result);
+            result = delTxn.Commit();
+            Assert.Equal(MDBResultCode.Success, result);
+        }, DatabaseOpenFlags.Create | DatabaseOpenFlags.DuplicatesFixed);
+    }
+
+    [Fact]
+    public void TransactionShouldBeCreated()
+    {
+        _env.RunTransactionScenario((tx, _) =>
+        {
+            Assert.Equal(LightningTransactionState.Active, tx.State);
+        });
+    }
+
+    [Fact]
+    public void TransactionShouldBeAbortedIfEnvironmentCloses()
+    {
+        _env.RunTransactionScenario((tx, _) =>
         {
             _env.Dispose();
-        }
-        
-        [Fact]
-        public void CanDeletePreviouslyCommittedWithMultipleValuesByPassingNullForValue()
-        {
-            _env.RunTransactionScenario((tx, db) =>
-            {
-                var key = MemoryMarshal.Cast<char, byte>("abcd");
+            Assert.Equal(LightningTransactionState.Aborted, tx.State);
+        });
+    }
 
-                tx.Put(db, key, MemoryMarshal.Cast<char, byte>("Value1"));
-                tx.Put(db, key, MemoryMarshal.Cast<char, byte>("Value2"), PutOptions.AppendData);
-                tx.Commit();
-                tx.Dispose();
-                
-                using var delTxn = _env.BeginTransaction();
-                var result = delTxn.Delete(db, key, null);
-                Assert.Equal(MDBResultCode.Success, result);
-                result = delTxn.Commit();
-                Assert.Equal(MDBResultCode.Success, result);
-            }, DatabaseOpenFlags.Create | DatabaseOpenFlags.DuplicatesFixed);
-        }
-
-        [Fact]
-        public void TransactionShouldBeCreated()
+    [Fact]
+    public void TransactionShouldChangeStateOnCommit()
+    {
+        _env.RunTransactionScenario((tx, _) =>
         {
-            _env.RunTransactionScenario((tx, db) =>
-            {
-                Assert.Equal(LightningTransactionState.Active, tx.State);
-            });
-        }
+            tx.Commit();
+            Assert.Equal(LightningTransactionState.Committed, tx.State);
+        });
+    }
 
-        [Fact]
-        public void TransactionShouldBeAbortedIfEnvironmentCloses()
+    [Fact]
+    public void ChildTransactionShouldBeCreated()
+    {
+        _env.RunTransactionScenario((tx, _) =>
         {
-            _env.RunTransactionScenario((tx, db) =>
-            {
-                _env.Dispose();
-                Assert.Equal(LightningTransactionState.Aborted, tx.State);
-            });
-        }
+            var subTxn = tx.BeginTransaction();
+            Assert.Equal(LightningTransactionState.Active, subTxn.State);
+        });
+    }
 
-        [Fact]
-        public void TransactionShouldChangeStateOnCommit()
+    [Fact]
+    public void ResetTransactionAbortedOnDispose()
+    {
+        _env.RunTransactionScenario((tx, _) =>
         {
-            _env.RunTransactionScenario((tx, db) =>
-            {
-                tx.Commit();
-                Assert.Equal(LightningTransactionState.Commited, tx.State);
-            });
-        }
+            tx.Reset();
+            tx.Dispose();
+            Assert.Equal(LightningTransactionState.Aborted, tx.State);
+        }, transactionFlags: TransactionBeginFlags.ReadOnly);
+    }
 
-        [Fact]
-        public void ChildTransactionShouldBeCreated()
+    [Fact]
+    public void ChildTransactionShouldBeAbortedIfParentIsAborted()
+    {
+        _env.RunTransactionScenario((tx, _) =>
         {
-            _env.RunTransactionScenario((tx, db) =>
-            {
-                var subTxn = tx.BeginTransaction();
-                Assert.Equal(LightningTransactionState.Active, subTxn.State);
-            });
-        }
+            var child = tx.BeginTransaction();
+            tx.Abort();
+            Assert.Equal(LightningTransactionState.Aborted, child.State);
+        });
+    }
 
-        [Fact]
-        public void ResetTransactionAbortedOnDispose()
+    [Fact]
+    public void ChildTransactionShouldBeAbortedIfParentIsCommitted()
+    {
+        _env.RunTransactionScenario((tx, _) =>
         {
-            _env.RunTransactionScenario((tx, db) =>
-            {
-                tx.Reset();
-                tx.Dispose();
-                Assert.Equal(LightningTransactionState.Aborted, tx.State);
-            }, transactionFlags: TransactionBeginFlags.ReadOnly);
-        }
+            var child = tx.BeginTransaction();
+            tx.Commit();
+            Assert.Equal(LightningTransactionState.Aborted, child.State);
+        });
+    }
 
-        [Fact]
-        public void ChildTransactionShouldBeAbortedIfParentIsAborted()
+    [Fact]
+    public void ChildTransactionShouldBeAbortedIfEnvironmentIsClosed()
+    {
+        _env.RunTransactionScenario((tx, _) =>
         {
-            _env.RunTransactionScenario((tx, db) =>
-            {
-                var child = tx.BeginTransaction();
-                tx.Abort();
-                Assert.Equal(LightningTransactionState.Aborted, child.State);
-            });
-        }
+            var child = tx.BeginTransaction();
+            _env.Dispose();
+            Assert.Equal(LightningTransactionState.Aborted, child.State);
+        });
+    }
 
-        [Fact]
-        public void ChildTransactionShouldBeAbortedIfParentIsCommited()
+    [Fact]
+    public void ReadOnlyTransactionShouldChangeStateOnReset()
+    {
+        _env.RunTransactionScenario((tx, _) =>
         {
-            _env.RunTransactionScenario((tx, db) =>
-            {
-                var child = tx.BeginTransaction();
-                tx.Commit();
-                Assert.Equal(LightningTransactionState.Aborted, child.State);
-            });
-        }
+            tx.Reset();
+            Assert.Equal(LightningTransactionState.Reset, tx.State);
+        }, transactionFlags: TransactionBeginFlags.ReadOnly);
+    }
 
-        [Fact]
-        public void ChildTransactionShouldBeAbortedIfEnvironmentIsClosed()
+    [Fact]
+    public void ReadOnlyTransactionShouldChangeStateOnRenew()
+    {
+        _env.RunTransactionScenario((tx, _) =>
         {
-            _env.RunTransactionScenario((tx, db) =>
-            {
-                var child = tx.BeginTransaction();
-                _env.Dispose();
-                Assert.Equal(LightningTransactionState.Aborted, child.State);
-            });
-        }
+            tx.Reset();
+            tx.Renew();
+            Assert.Equal(LightningTransactionState.Active, tx.State);
+        }, transactionFlags: TransactionBeginFlags.ReadOnly);
+    }
 
-        [Fact]
-        public void ReadOnlyTransactionShouldChangeStateOnReset()
+    [Fact]
+    public void CanCountTransactionEntries()
+    {
+        _env.RunTransactionScenario((tx, db) =>
         {
-            _env.RunTransactionScenario((tx, db) =>
-            {
-                tx.Reset();
-                Assert.Equal(LightningTransactionState.Reseted, tx.State);
-            }, transactionFlags: TransactionBeginFlags.ReadOnly);
-        }
+            const int entriesCount = 10;
+            for (var i = 0; i < entriesCount; i++)
+                tx.Put(db, i.ToString(), i.ToString());
 
-        [Fact]
-        public void ReadOnlyTransactionShouldChangeStateOnRenew()
+            var count = tx.GetEntriesCount(db);
+            Assert.Equal(entriesCount, count);
+        });
+    }
+
+    [Fact]
+    public void TransactionShouldSupportCustomComparer()
+    {
+        int Comparison(int l, int r) => l.CompareTo(r);
+        var options = new DatabaseConfiguration {Flags = DatabaseOpenFlags.Create};
+        int CompareWith(MDBValue l, MDBValue r) => Comparison(BitConverter.ToInt32(l.CopyToNewArray(), 0), BitConverter.ToInt32(r.CopyToNewArray(), 0));
+        options.CompareWith(Comparer<MDBValue>.Create(new Comparison<MDBValue>((Func<MDBValue, MDBValue, int>)CompareWith)));
+
+        using (var txnT = _env.BeginTransaction())
+        using (var db1 = txnT.OpenDatabase(configuration: options))
         {
-            _env.RunTransactionScenario((tx, db) =>
-            {
-                tx.Reset();
-                tx.Renew();
-                Assert.Equal(LightningTransactionState.Active, tx.State);
-            }, transactionFlags: TransactionBeginFlags.ReadOnly);
+            txnT.DropDatabase(db1);
+            txnT.Commit();
         }
 
-        [Fact]
-        public void CanCountTransactionEntries()
-        {
-            _env.RunTransactionScenario((tx, db) =>
-            {
-                const int entriesCount = 10;
-                for (var i = 0; i < entriesCount; i++)
-                    tx.Put(db, i.ToString(), i.ToString());
+        var txn = _env.BeginTransaction();
+        var db = txn.OpenDatabase(configuration: options);
 
-                var count = tx.GetEntriesCount(db);
-                Assert.Equal(entriesCount, count);
-            });
+        var keysUnsorted = Enumerable.Range(1, 10000).OrderBy(_ => Guid.NewGuid()).ToList();
+        var keysSorted = keysUnsorted.ToArray();
+        Array.Sort(keysSorted, new Comparison<int>((Func<int, int, int>)Comparison));
+
+        GC.Collect();
+        for (var i = 0; i < keysUnsorted.Count; i++)
+            txn.Put(db, BitConverter.GetBytes(keysUnsorted[i]), BitConverter.GetBytes(i));
+
+        using (var c = txn.CreateCursor(db))
+        {
+            var order = 0;
+            while (c.Next() == MDBResultCode.Success)
+                Assert.Equal(keysSorted[order++], BitConverter.ToInt32(c.GetCurrent().key.CopyToNewArray(), 0));
         }
+    }
 
-        [Fact]
-        public void TransactionShouldSupportCustomComparer()
+    [Fact]
+    public void TransactionShouldSupportCustomDupSorter()
+    {
+        int Comparison(int l, int r) => -Math.Sign(l - r);
+
+        var txn = _env.BeginTransaction();
+        var options = new DatabaseConfiguration {Flags = DatabaseOpenFlags.Create | DatabaseOpenFlags.DuplicatesFixed};
+        int CompareWith(MDBValue l, MDBValue r) => Comparison(BitConverter.ToInt32(l.CopyToNewArray(), 0), BitConverter.ToInt32(r.CopyToNewArray(), 0));
+        options.FindDuplicatesWith(Comparer<MDBValue>.Create(new Comparison<MDBValue>((Func<MDBValue, MDBValue, int>)CompareWith)));
+        var db = txn.OpenDatabase(configuration: options);
+
+        var valuesUnsorted = new [] { 2, 10, 5, 0 };
+        var valuesSorted = valuesUnsorted.ToArray();
+        Array.Sort(valuesSorted, new Comparison<int>((Func<int, int, int>)Comparison));
+
+        using (var c = txn.CreateCursor(db))
+            c.Put(BitConverter.GetBytes(123), valuesUnsorted.Select(BitConverter.GetBytes).ToArray());
+
+        using (var c = txn.CreateCursor(db))
         {
-            Func<int, int, int> comparison = (l, r) => l.CompareTo(r);
-            var options = new DatabaseConfiguration {Flags = DatabaseOpenFlags.Create};
-            Func<MDBValue, MDBValue, int> compareWith =
-                (l, r) => comparison(BitConverter.ToInt32(l.CopyToNewArray(), 0), BitConverter.ToInt32(r.CopyToNewArray(), 0));
-            options.CompareWith(Comparer<MDBValue>.Create(new Comparison<MDBValue>(compareWith)));
+            var order = 0;
 
-            using (var txnT = _env.BeginTransaction())
-            using (var db1 = txnT.OpenDatabase(configuration: options))
-            {
-                txnT.DropDatabase(db1);
-                txnT.Commit();
-            }
-
-            var txn = _env.BeginTransaction();
-            var db = txn.OpenDatabase(configuration: options);
-
-            var keysUnsorted = Enumerable.Range(1, 10000).OrderBy(x => Guid.NewGuid()).ToList();
-            var keysSorted = keysUnsorted.ToArray();
-            Array.Sort(keysSorted, new Comparison<int>(comparison));
-
-            GC.Collect();
-            for (var i = 0; i < keysUnsorted.Count; i++)
-                txn.Put(db, BitConverter.GetBytes(keysUnsorted[i]), BitConverter.GetBytes(i));
-
-            using (var c = txn.CreateCursor(db))
-            {
-                int order = 0;
-                while (c.Next() == MDBResultCode.Success)
-                    Assert.Equal(keysSorted[order++], BitConverter.ToInt32(c.GetCurrent().key.CopyToNewArray(), 0));
-            }
-        }
-
-        [Fact]
-        public void TransactionShouldSupportCustomDupSorter()
-        {
-            Func<int, int, int> comparison = (l, r) => -Math.Sign(l - r);
-
-            var txn = _env.BeginTransaction();
-            var options = new DatabaseConfiguration {Flags = DatabaseOpenFlags.Create | DatabaseOpenFlags.DuplicatesFixed};
-            Func<MDBValue, MDBValue, int> compareWith = (l, r) => comparison(BitConverter.ToInt32(l.CopyToNewArray(), 0), BitConverter.ToInt32(r.CopyToNewArray(), 0));
-            options.FindDuplicatesWith(Comparer<MDBValue>.Create(new Comparison<MDBValue>(compareWith)));
-            var db = txn.OpenDatabase(configuration: options);
-
-            var valuesUnsorted = new [] { 2, 10, 5, 0 };
-            var valuesSorted = valuesUnsorted.ToArray();
-            Array.Sort(valuesSorted, new Comparison<int>(comparison));
-
-            using (var c = txn.CreateCursor(db))
-                c.Put(BitConverter.GetBytes(123), valuesUnsorted.Select(BitConverter.GetBytes).ToArray());
-
-            using (var c = txn.CreateCursor(db))
-            {
-                int order = 0;
-
-                while (c.Next() == MDBResultCode.Success)
-                    Assert.Equal(valuesSorted[order++], BitConverter.ToInt32(c.GetCurrent().value.CopyToNewArray(), 0));
-            }
+            while (c.Next() == MDBResultCode.Success)
+                Assert.Equal(valuesSorted[order++], BitConverter.ToInt32(c.GetCurrent().value.CopyToNewArray(), 0));
         }
     }
 }

--- a/src/LightningDB/CursorDeleteOption.cs
+++ b/src/LightningDB/CursorDeleteOption.cs
@@ -1,20 +1,19 @@
-﻿namespace LightningDB
+﻿namespace LightningDB;
+
+/// <summary>
+/// Cursor delete operation options
+/// </summary>
+public enum CursorDeleteOption
 {
     /// <summary>
-    /// Cursor delete operation options
+    /// No special behavior
     /// </summary>
-    public enum CursorDeleteOption
-    {
-        /// <summary>
-        /// No special behavior
-        /// </summary>
-        None = 0,
+    None = 0,
 
-        /// <summary>
-        /// Only for MDB_DUPSORT
-        /// For put: don't write if the key and data pair already exist.
-        /// For mdb_cursor_del: remove all duplicate data items.
-        /// </summary>
-        NoDuplicateData = 0x20
-    }
+    /// <summary>
+    /// Only for MDB_DUPSORT
+    /// For put: don't write if the key and data pair already exist.
+    /// For mdb_cursor_del: remove all duplicate data items.
+    /// </summary>
+    NoDuplicateData = 0x20
 }

--- a/src/LightningDB/CursorOperation.cs
+++ b/src/LightningDB/CursorOperation.cs
@@ -1,98 +1,97 @@
-﻿namespace LightningDB
+﻿namespace LightningDB;
+
+/// <summary>
+/// Cursor operation types
+/// </summary>
+public enum CursorOperation
 {
     /// <summary>
-    /// Cursor operation types
+    /// Position at first key/data item
     /// </summary>
-    public enum CursorOperation
-    {
-        /// <summary>
-        /// Position at first key/data item
-        /// </summary>
-        First,
+    First,
 
-        /// <summary>
-        /// Position at first data item of current key. Only for MDB_DUPSORT
-        /// </summary>
-        FirstDuplicate,
+    /// <summary>
+    /// Position at first data item of current key. Only for MDB_DUPSORT
+    /// </summary>
+    FirstDuplicate,
 
-        /// <summary>
-        /// Position at key/data pair. Only for MDB_DUPSORT
-        /// </summary>
-        GetBoth,
+    /// <summary>
+    /// Position at key/data pair. Only for MDB_DUPSORT
+    /// </summary>
+    GetBoth,
 
-        /// <summary>
-        /// position at key, nearest data. Only for MDB_DUPSORT
-        /// </summary>
-        GetBothRange,
+    /// <summary>
+    /// position at key, nearest data. Only for MDB_DUPSORT
+    /// </summary>
+    GetBothRange,
 
-        /// <summary>
-        /// Return key/data at current cursor position
-        /// </summary>
-        GetCurrent,
+    /// <summary>
+    /// Return key/data at current cursor position
+    /// </summary>
+    GetCurrent,
 
-        /// <summary>
-        /// Return all the duplicate data items at the current cursor position. Only for MDB_DUPFIXED
-        /// </summary>
-        GetMultiple,
+    /// <summary>
+    /// Return all the duplicate data items at the current cursor position. Only for MDB_DUPFIXED
+    /// </summary>
+    GetMultiple,
 
-        /// <summary>
-        /// Position at last key/data item
-        /// </summary>
-        Last,
+    /// <summary>
+    /// Position at last key/data item
+    /// </summary>
+    Last,
 
-        /// <summary>
-        /// Position at last data item of current key. Only for MDB_DUPSORT
-        /// </summary>
-        LastDuplicate,
+    /// <summary>
+    /// Position at last data item of current key. Only for MDB_DUPSORT
+    /// </summary>
+    LastDuplicate,
 
-        /// <summary>
-        /// Position at next data item
-        /// </summary>
-        Next,
+    /// <summary>
+    /// Position at next data item
+    /// </summary>
+    Next,
 
-        /// <summary>
-        /// Position at next data item of current key. Only for MDB_DUPSORT
-        /// </summary>
-        NextDuplicate,
+    /// <summary>
+    /// Position at next data item of current key. Only for MDB_DUPSORT
+    /// </summary>
+    NextDuplicate,
 
-        /// <summary>
-        /// Return all duplicate data items at the next cursor position. Only for MDB_DUPFIXED
-        /// </summary>
-        NextMultiple,
+    /// <summary>
+    /// Return all duplicate data items at the next cursor position. Only for MDB_DUPFIXED
+    /// </summary>
+    NextMultiple,
 
-        /// <summary>
-        /// Position at first data item of next key. Only for MDB_DUPSORT
-        /// </summary>
-        NextNoDuplicate,
+    /// <summary>
+    /// Position at first data item of next key. Only for MDB_DUPSORT
+    /// </summary>
+    NextNoDuplicate,
 
-        /// <summary>
-        /// Position at previous data item
-        /// </summary>
-        Previous,
+    /// <summary>
+    /// Position at previous data item
+    /// </summary>
+    Previous,
 
-        /// <summary>
-        /// Position at previous data item of current key. Only for MDB_DUPSORT
-        /// </summary>
-        PreviousDuplicate,
+    /// <summary>
+    /// Position at previous data item of current key. Only for MDB_DUPSORT
+    /// </summary>
+    PreviousDuplicate,
 
-        /// <summary>
-        /// Position at last data item of previous key. Only for MDB_DUPSORT
-        /// </summary>
-        PreviousNoDuplicate,
+    /// <summary>
+    /// Position at last data item of previous key. Only for MDB_DUPSORT
+    /// </summary>
+    PreviousNoDuplicate,
 
-        /// <summary>
-        /// Position at specified key
-        /// </summary>
-        Set,
+    /// <summary>
+    /// Position at specified key
+    /// </summary>
+    Set,
 
-        /// <summary>
-        /// Position at specified key, return key + data
-        /// </summary>
-        SetKey,
+    /// <summary>
+    /// Position at specified key, return key + data
+    /// </summary>
+    SetKey,
 
-        /// <summary>
-        /// Position at first key greater than or equal to specified key.
-        /// </summary>
-        SetRange,
-    }
+    /// <summary>
+    /// Position at first key greater than or equal to specified key.
+    /// </summary>
+    SetRange
 }

--- a/src/LightningDB/CursorPutOptions.cs
+++ b/src/LightningDB/CursorPutOptions.cs
@@ -1,50 +1,49 @@
-﻿namespace LightningDB
+﻿namespace LightningDB;
+
+/// <summary>
+/// Special options for cursor put operation.
+/// </summary>
+public enum CursorPutOptions
 {
     /// <summary>
-    /// Special options for cursor put operation.
+    /// No special behavior.
     /// </summary>
-    public enum CursorPutOptions
-    {
-        /// <summary>
-        /// No special behavior.
-        /// </summary>
-        None = 0,
+    None = 0,
 
-        /// <summary>
-        /// Overwrite the current key/data pair
-        /// </summary>
-        Current = 0x40,
+    /// <summary>
+    /// Overwrite the current key/data pair
+    /// </summary>
+    Current = 0x40,
 
-        /// <summary>
-        /// Only for MDB_DUPSORT
-        /// For put: don't write if the key and data pair already exist.
-        /// For mdb_cursor_del: remove all duplicate data items.
-        /// </summary>
-        NoDuplicateData = 0x20,
+    /// <summary>
+    /// Only for MDB_DUPSORT
+    /// For put: don't write if the key and data pair already exist.
+    /// For mdb_cursor_del: remove all duplicate data items.
+    /// </summary>
+    NoDuplicateData = 0x20,
 
-        /// <summary>
-        /// For put: Don't write if the key already exists.
-        /// </summary>
-        NoOverwrite = 0x10,
+    /// <summary>
+    /// For put: Don't write if the key already exists.
+    /// </summary>
+    NoOverwrite = 0x10,
 
-        /// <summary>
-        /// For put: Just reserve space for data, don't copy it. Return a pointer to the reserved space.
-        /// </summary>
-        ReserveSpace = 0x10000,
+    /// <summary>
+    /// For put: Just reserve space for data, don't copy it. Return a pointer to the reserved space.
+    /// </summary>
+    ReserveSpace = 0x10000,
 
-        /// <summary>
-        /// Data is being appended, don't split full pages.
-        /// </summary>
-        AppendData = 0x20000,
+    /// <summary>
+    /// Data is being appended, don't split full pages.
+    /// </summary>
+    AppendData = 0x20000,
 
-        /// <summary>
-        /// Duplicate data is being appended, don't split full pages.
-        /// </summary>
-        AppendDuplicateData = 0x40000,
+    /// <summary>
+    /// Duplicate data is being appended, don't split full pages.
+    /// </summary>
+    AppendDuplicateData = 0x40000,
 
-        /// <summary>
-        /// Store multiple data items in one call. Only for MDB_DUPFIXED.
-        /// </summary>
-        MultipleData = 0x80000
-    }
+    /// <summary>
+    /// Store multiple data items in one call. Only for MDB_DUPFIXED.
+    /// </summary>
+    MultipleData = 0x80000
 }

--- a/src/LightningDB/DatabaseConfiguration.cs
+++ b/src/LightningDB/DatabaseConfiguration.cs
@@ -4,75 +4,73 @@ using System.Runtime.InteropServices;
 using LightningDB.Native;
 using static LightningDB.Native.Lmdb;
 
-namespace LightningDB
+namespace LightningDB;
+
+public class DatabaseConfiguration
 {
-    public class DatabaseConfiguration
+    private IComparer<MDBValue> _comparer;
+    private IComparer<MDBValue> _duplicatesComparer;
+
+    public DatabaseConfiguration()
     {
-        private IComparer<MDBValue> _comparer;
-        private IComparer<MDBValue> _duplicatesComparer;
+        Flags = DatabaseOpenFlags.None;
+    }
 
-        public DatabaseConfiguration()
+    public DatabaseOpenFlags Flags { get; set; }
+
+
+    internal IDisposable ConfigureDatabase(LightningTransaction tx, LightningDatabase db)
+    {
+        var pinnedComparer = new ComparerKeepAlive();
+        if (_comparer != null)
         {
-            Flags = DatabaseOpenFlags.None;
+            CompareFunction compare = Compare;
+            pinnedComparer.AddComparer(compare);
+            mdb_set_compare(tx.Handle(), db.Handle(), compare);
         }
 
-        public DatabaseOpenFlags Flags { get; set; }
+        if (_duplicatesComparer == null) return pinnedComparer;
+        CompareFunction dupCompare = IsDuplicate;
+        pinnedComparer.AddComparer(dupCompare);
+        mdb_set_dupsort(tx.Handle(), db.Handle(), dupCompare);
+        return pinnedComparer;
+    }
 
+    private int Compare(ref MDBValue left, ref MDBValue right)
+    {
+        return _comparer.Compare(left, right);
+    }
 
-        internal IDisposable ConfigureDatabase(LightningTransaction tx, LightningDatabase db)
+    private int IsDuplicate(ref MDBValue left, ref MDBValue right)
+    {
+        return _duplicatesComparer.Compare(left, right);
+    }
+
+    public void CompareWith(IComparer<MDBValue> comparer)
+    {
+        _comparer = comparer;
+    }
+
+    public void FindDuplicatesWith(IComparer<MDBValue> comparer)
+    {
+        _duplicatesComparer = comparer;
+    }
+
+    private class ComparerKeepAlive : IDisposable
+    {
+        private readonly List<GCHandle> _comparisons = new();
+
+        public void AddComparer(CompareFunction compare)
         {
-            var pinnedComparer = new ComparerKeepAlive();
-            if (_comparer != null)
+            var handle = GCHandle.Alloc(compare);
+            _comparisons.Add(handle);
+        }
+
+        public void Dispose()
+        {
+            for (var i = 0; i < _comparisons.Count; ++i)
             {
-                CompareFunction compare = Compare;
-                pinnedComparer.AddComparer(compare);
-                mdb_set_compare(tx.Handle(), db.Handle(), compare);
-            }
-            if (_duplicatesComparer != null)
-            {
-                CompareFunction dupCompare = IsDuplicate;
-                pinnedComparer.AddComparer(dupCompare);
-                mdb_set_dupsort(tx.Handle(), db.Handle(), dupCompare);
-            }
-            return pinnedComparer;
-        }
-
-        private int Compare(ref MDBValue left, ref MDBValue right)
-        {
-            return _comparer.Compare(left, right);
-        }
-
-        private int IsDuplicate(ref MDBValue left, ref MDBValue right)
-        {
-            return _duplicatesComparer.Compare(left, right);
-        }
-
-        public void CompareWith(IComparer<MDBValue> comparer)
-        {
-            _comparer = comparer;
-        }
-
-        public void FindDuplicatesWith(IComparer<MDBValue> comparer)
-        {
-            _duplicatesComparer = comparer;
-        }
-
-        private class ComparerKeepAlive : IDisposable
-        {
-            private readonly List<GCHandle> _comparisons = new List<GCHandle>();
-
-            public void AddComparer(CompareFunction compare)
-            {
-                var handle = GCHandle.Alloc(compare);
-                _comparisons.Add(handle);
-            }
-
-            public void Dispose()
-            {
-                for (int i = 0; i < _comparisons.Count; ++i)
-                {
-                    _comparisons[i].Free();
-                }
+                _comparisons[i].Free();
             }
         }
     }

--- a/src/LightningDB/DatabaseOpenFlags.cs
+++ b/src/LightningDB/DatabaseOpenFlags.cs
@@ -1,53 +1,52 @@
 ﻿using System;
 using LightningDB.Native;
 
-namespace LightningDB
+namespace LightningDB;
+
+/// <summary>
+/// Flags to open a database with.
+/// </summary>
+[Flags]
+public enum DatabaseOpenFlags
 {
     /// <summary>
-    /// Flags to open a database with.
+    /// No special options.
     /// </summary>
-    [Flags]
-    public enum DatabaseOpenFlags
-    {
-        /// <summary>
-        /// No special options.
-        /// </summary>
-        None = 0,
+    None = 0,
                 
-        /// <summary>
-        /// MDB_REVERSEKEY. Keys are strings to be compared in reverse order, from the end of the strings to the beginning. By default, Keys are treated as strings and compared from beginning to end.
-        /// </summary>
-        ReverseKey = 0x02,
+    /// <summary>
+    /// MDB_REVERSEKEY. Keys are strings to be compared in reverse order, from the end of the strings to the beginning. By default, Keys are treated as strings and compared from beginning to end.
+    /// </summary>
+    ReverseKey = 0x02,
 
-        /// <summary>
-        /// MDB_DUPSORT. Duplicate keys may be used in the database. (Or, from another perspective, keys may have multiple data items, stored in sorted order.) By default keys must be unique and may have only a single data item.
-        /// </summary>
-        DuplicatesSort = Lmdb.MDB_DUPSORT,
+    /// <summary>
+    /// MDB_DUPSORT. Duplicate keys may be used in the database. (Or, from another perspective, keys may have multiple data items, stored in sorted order.) By default keys must be unique and may have only a single data item.
+    /// </summary>
+    DuplicatesSort = Lmdb.MDB_DUPSORT,
 
-        /// <summary>
-        /// MDB_INTEGERKEY. Keys are binary integers in native byte order. 
-        /// Setting this option requires all keys to be the same size, typically sizeof(int) or sizeof(size_t).
-        /// </summary>
-        IntegerKey = 0x08,
+    /// <summary>
+    /// MDB_INTEGERKEY. Keys are binary integers in native byte order. 
+    /// Setting this option requires all keys to be the same size, typically sizeof(int) or sizeof(size_t).
+    /// </summary>
+    IntegerKey = 0x08,
 
-        /// <summary>
-        /// MDB_DUPFIXED. This flag may only be used in combination with MDB_DUPSORT. This option tells the library that the data items for this database are all the same size, which allows further optimizations in storage and retrieval. When all data items are the same size, the MDB_GET_MULTIPLE and MDB_NEXT_MULTIPLE cursor operations may be used to retrieve multiple items at once.
-        /// </summary>
-        DuplicatesFixed = Lmdb.MDB_DUPSORT | Lmdb.MDB_DUPFIXED,
+    /// <summary>
+    /// MDB_DUPFIXED. This flag may only be used in combination with MDB_DUPSORT. This option tells the library that the data items for this database are all the same size, which allows further optimizations in storage and retrieval. When all data items are the same size, the MDB_GET_MULTIPLE and MDB_NEXT_MULTIPLE cursor operations may be used to retrieve multiple items at once.
+    /// </summary>
+    DuplicatesFixed = Lmdb.MDB_DUPSORT | Lmdb.MDB_DUPFIXED,
 
-        /// <summary>
-        /// MDB_INTEGERDUP. This option specifies that duplicate data items are also integers, and should be sorted as such.
-        /// </summary>
-        IntegerDuplicates = 0x20,
+    /// <summary>
+    /// MDB_INTEGERDUP. This option specifies that duplicate data items are also integers, and should be sorted as such.
+    /// </summary>
+    IntegerDuplicates = 0x20,
 
-        /// <summary>
-        /// MDB_REVERSEDUP. This option specifies that duplicate data items should be compared as strings in reverse order.
-        /// </summary>
-        ReverseDuplicates = 0x40,
+    /// <summary>
+    /// MDB_REVERSEDUP. This option specifies that duplicate data items should be compared as strings in reverse order.
+    /// </summary>
+    ReverseDuplicates = 0x40,
 
-        /// <summary>
-        /// Create the named database if it doesn't exist. This option is not allowed in a read-only transaction or a read-only environment.
-        /// </summary>
-        Create = 0x40000
-    }
+    /// <summary>
+    /// Create the named database if it doesn't exist. This option is not allowed in a read-only transaction or a read-only environment.
+    /// </summary>
+    Create = 0x40000
 }

--- a/src/LightningDB/EnvironmentConfiguration.cs
+++ b/src/LightningDB/EnvironmentConfiguration.cs
@@ -1,54 +1,53 @@
-﻿namespace LightningDB
+﻿namespace LightningDB;
+
+/// <summary>
+/// Basic environment configuration
+/// </summary>
+public class EnvironmentConfiguration
 {
-    /// <summary>
-    /// Basic environment configuration
-    /// </summary>
-    public class EnvironmentConfiguration
-    {
-        private long? _mapSize;
-        private int? _maxReaders;
-        private int? _maxDatabases;
+    private long? _mapSize;
+    private int? _maxReaders;
+    private int? _maxDatabases;
         
 #if NETCOREAPP3_1_OR_GREATER
-        private bool? _autoResizeWindows;
+    private bool? _autoResizeWindows;
         
-        public bool AutoResizeWindows
-        {
-            get { return _autoResizeWindows ?? false; }
-            set { _autoResizeWindows = value; }
-        }
+    public bool AutoResizeWindows
+    {
+        get => _autoResizeWindows ?? false;
+        set => _autoResizeWindows = value;
+    }
 #endif
 
-        public long MapSize
-        {
-            get { return _mapSize ?? 0; }
-            set { _mapSize = value; }
-        }
+    public long MapSize
+    {
+        get => _mapSize ?? 0;
+        set => _mapSize = value;
+    }
 
-        public int MaxReaders
-        {
-            get { return _maxReaders ?? 0; }
-            set { _maxReaders = value; }
-        }
+    public int MaxReaders
+    {
+        get => _maxReaders ?? 0;
+        set => _maxReaders = value;
+    }
 
-        public int MaxDatabases
-        {
-            get { return _maxDatabases ?? 0; }
-            set { _maxDatabases = value; }
-        }
+    public int MaxDatabases
+    {
+        get => _maxDatabases ?? 0;
+        set => _maxDatabases = value;
+    }
 
-        public bool AutoReduceMapSizeIn32BitProcess { get; set; }
+    public bool AutoReduceMapSizeIn32BitProcess { get; set; }
 
-        internal void Configure(LightningEnvironment env)
-        {
-            if (_mapSize.HasValue)
-                env.MapSize = _mapSize.Value;
+    internal void Configure(LightningEnvironment env)
+    {
+        if (_mapSize.HasValue)
+            env.MapSize = _mapSize.Value;
 
-            if (_maxDatabases.HasValue)
-                env.MaxDatabases = _maxDatabases.Value;
+        if (_maxDatabases.HasValue)
+            env.MaxDatabases = _maxDatabases.Value;
 
-            if (_maxReaders.HasValue)
-                env.MaxReaders = _maxReaders.Value;
-        }
+        if (_maxReaders.HasValue)
+            env.MaxReaders = _maxReaders.Value;
     }
 }

--- a/src/LightningDB/EnvironmentCopyFlags.cs
+++ b/src/LightningDB/EnvironmentCopyFlags.cs
@@ -1,12 +1,11 @@
-﻿namespace LightningDB
-{
-    public enum EnvironmentCopyFlags
-    {
-        None = 0,
+﻿namespace LightningDB;
 
-        /// <summary>
-        /// MDB_CP_COMPACT. Compacting copy: Omit free space from copy, and renumber all pages sequentially.
-        /// </summary>
-        Compact = 0x01
-    }
+public enum EnvironmentCopyFlags
+{
+    None = 0,
+
+    /// <summary>
+    /// MDB_CP_COMPACT. Compacting copy: Omit free space from copy, and renumber all pages sequentially.
+    /// </summary>
+    Compact = 0x01
 }

--- a/src/LightningDB/EnvironmentInfo.cs
+++ b/src/LightningDB/EnvironmentInfo.cs
@@ -1,23 +1,22 @@
-namespace LightningDB
+namespace LightningDB;
+
+/// <summary>
+/// Information about the environment. 
+/// </summary>
+public class EnvironmentInfo
 {
     /// <summary>
-    /// Information about the environment. 
+    /// ID of the last used page 
     /// </summary>
-    public class EnvironmentInfo
-    {
-        /// <summary>
-        /// ID of the last used page 
-        /// </summary>
-        public long LastPageNumber { get; set; }
+    public long LastPageNumber { get; set; }
 
-        /// <summary>
-        /// ID of the last committed transaction  
-        /// </summary>
-        public long LastTransactionId { get; set; }
+    /// <summary>
+    /// ID of the last committed transaction  
+    /// </summary>
+    public long LastTransactionId { get; set; }
 
-        /// <summary>
-        /// Size of the data memory map 
-        /// </summary>
-        public long MapSize { get; set; }
-    }
+    /// <summary>
+    /// Size of the data memory map 
+    /// </summary>
+    public long MapSize { get; set; }
 }

--- a/src/LightningDB/EnvironmentOpenFlags.cs
+++ b/src/LightningDB/EnvironmentOpenFlags.cs
@@ -1,96 +1,95 @@
 ﻿using System;
 
-namespace LightningDB
+namespace LightningDB;
+
+/// <summary>
+/// Options to open LMDB environment
+/// </summary>
+[Flags]
+public enum EnvironmentOpenFlags
 {
     /// <summary>
-    /// Options to open LMDB environment
+    /// No special options.
     /// </summary>
-    [Flags]
-    public enum EnvironmentOpenFlags
-    {
-        /// <summary>
-        /// No special options.
-        /// </summary>
-        None = 0,
+    None = 0,
 
-        /// <summary>
-        /// MDB_FIXEDMAP. use a fixed address for the mmap region. 
-        /// This flag must be specified when creating the environment, and is stored persistently in the environment. 
-        /// If successful, the memory map will always reside at the same virtual address and pointers used to reference data items in the database will be constant across multiple invocations. 
-        /// This option may not always work, depending on how the operating system has allocated memory to shared libraries and other uses. 
-        /// The feature is highly experimental.
-        /// </summary>
-        FixedMap = 0x01,
+    /// <summary>
+    /// MDB_FIXEDMAP. use a fixed address for the mmap region. 
+    /// This flag must be specified when creating the environment, and is stored persistently in the environment. 
+    /// If successful, the memory map will always reside at the same virtual address and pointers used to reference data items in the database will be constant across multiple invocations. 
+    /// This option may not always work, depending on how the operating system has allocated memory to shared libraries and other uses. 
+    /// The feature is highly experimental.
+    /// </summary>
+    FixedMap = 0x01,
 
-        /// <summary>
-        /// MDB_NOSUBDIR. By default, MDB creates its environment in a directory whose pathname is given in path, and creates its data and lock files under that directory. 
-        /// With this option, path is used as-is for the database main data file. 
-        /// The database lock file is the path with "-lock" appended.
-        /// </summary>
-        NoSubDir = 0x4000,
+    /// <summary>
+    /// MDB_NOSUBDIR. By default, MDB creates its environment in a directory whose pathname is given in path, and creates its data and lock files under that directory. 
+    /// With this option, path is used as-is for the database main data file. 
+    /// The database lock file is the path with "-lock" appended.
+    /// </summary>
+    NoSubDir = 0x4000,
 
-        /// <summary>
-        /// MDB_NOSYNC. Don't flush system buffers to disk when committing a transaction. 
-        /// This optimization means a system crash can corrupt the database or lose the last transactions if buffers are not yet flushed to disk. 
-        /// The risk is governed by how often the system flushes dirty buffers to disk and how often mdb_env_sync() is called. 
-        /// However, if the filesystem preserves write order and the MDB_WRITEMAP flag is not used, transactions exhibit ACI (atomicity, consistency, isolation) properties and only lose D (durability). 
-        /// I.e. database integrity is maintained, but a system crash may undo the final transactions. 
-        /// Note that (MDB_NOSYNC | MDB_WRITEMAP) leaves the system with no hint for when to write transactions to disk, unless mdb_env_sync() is called. 
-        /// (MDB_MAPASYNC | MDB_WRITEMAP) may be preferable. 
-        /// This flag may be changed at any time using mdb_env_set_flags().
-        /// </summary>
-        NoSync = 0x10000,
+    /// <summary>
+    /// MDB_NOSYNC. Don't flush system buffers to disk when committing a transaction. 
+    /// This optimization means a system crash can corrupt the database or lose the last transactions if buffers are not yet flushed to disk. 
+    /// The risk is governed by how often the system flushes dirty buffers to disk and how often mdb_env_sync() is called. 
+    /// However, if the filesystem preserves write order and the MDB_WRITEMAP flag is not used, transactions exhibit ACI (atomicity, consistency, isolation) properties and only lose D (durability). 
+    /// I.e. database integrity is maintained, but a system crash may undo the final transactions. 
+    /// Note that (MDB_NOSYNC | MDB_WRITEMAP) leaves the system with no hint for when to write transactions to disk, unless mdb_env_sync() is called. 
+    /// (MDB_MAPASYNC | MDB_WRITEMAP) may be preferable. 
+    /// This flag may be changed at any time using mdb_env_set_flags().
+    /// </summary>
+    NoSync = 0x10000,
         
-        /// <summary>
-        /// MDB_RDONLY. Open the environment in read-only mode. 
-        /// No write operations will be allowed. 
-        /// MDB will still modify the lock file - except on read-only filesystems, where MDB does not use locks.
-        /// </summary>
-        ReadOnly = 0x20000,
+    /// <summary>
+    /// MDB_RDONLY. Open the environment in read-only mode. 
+    /// No write operations will be allowed. 
+    /// MDB will still modify the lock file - except on read-only filesystems, where MDB does not use locks.
+    /// </summary>
+    ReadOnly = 0x20000,
 
-        /// <summary>
-        /// MDB_NOMETASYNC. Flush system buffers to disk only once per transaction, omit the metadata flush. 
-        /// Defer that until the system flushes files to disk, or next non-MDB_RDONLY commit or mdb_env_sync(). 
-        /// This optimization maintains database integrity, but a system crash may undo the last committed transaction. 
-        /// I.e. it preserves the ACI (atomicity, consistency, isolation) but not D (durability) database property. 
-        /// This flag may be changed at any time using mdb_env_set_flags().
-        /// </summary>
-        NoMetaSync = 0x40000,
+    /// <summary>
+    /// MDB_NOMETASYNC. Flush system buffers to disk only once per transaction, omit the metadata flush. 
+    /// Defer that until the system flushes files to disk, or next non-MDB_RDONLY commit or mdb_env_sync(). 
+    /// This optimization maintains database integrity, but a system crash may undo the last committed transaction. 
+    /// I.e. it preserves the ACI (atomicity, consistency, isolation) but not D (durability) database property. 
+    /// This flag may be changed at any time using mdb_env_set_flags().
+    /// </summary>
+    NoMetaSync = 0x40000,
         
-        /// <summary>
-        /// MDB_WRITEMAP Use a writeable memory map unless MDB_RDONLY is set. 
-        /// This is faster and uses fewer mallocs, but loses protection from application bugs like wild pointer writes and other bad updates into the database. 
-        /// Incompatible with nested transactions.
-        /// </summary>
-        WriteMap = 0x80000, 
+    /// <summary>
+    /// MDB_WRITEMAP Use a writeable memory map unless MDB_RDONLY is set. 
+    /// This is faster and uses fewer mallocs, but loses protection from application bugs like wild pointer writes and other bad updates into the database. 
+    /// Incompatible with nested transactions.
+    /// </summary>
+    WriteMap = 0x80000, 
 
-        /// <summary>
-        /// MDB_MAPASYNC. When using MDB_WRITEMAP, use asynchronous flushes to disk. 
-        /// As with MDB_NOSYNC, a system crash can then corrupt the database or lose the last transactions. 
-        /// Calling mdb_env_sync() ensures on-disk database integrity until next commit. 
-        /// This flag may be changed at any time using mdb_env_set_flags().
-        /// </summary>
-        MapAsync = 0x100000,
+    /// <summary>
+    /// MDB_MAPASYNC. When using MDB_WRITEMAP, use asynchronous flushes to disk. 
+    /// As with MDB_NOSYNC, a system crash can then corrupt the database or lose the last transactions. 
+    /// Calling mdb_env_sync() ensures on-disk database integrity until next commit. 
+    /// This flag may be changed at any time using mdb_env_set_flags().
+    /// </summary>
+    MapAsync = 0x100000,
 
-        /// <summary>
-        /// MDB_NOTLS. tie reader locktable slots to MDB_txn objects instead of to threads
-        /// </summary>
-        NoThreadLocalStorage = 0x200000,
+    /// <summary>
+    /// MDB_NOTLS. tie reader locktable slots to MDB_txn objects instead of to threads
+    /// </summary>
+    NoThreadLocalStorage = 0x200000,
 
-        /// <summary>
-        /// MDB_NOLOCK. don't do any locking, caller must manage their own locks
-        /// </summary>
-        NoLock = 0x400000,
+    /// <summary>
+    /// MDB_NOLOCK. don't do any locking, caller must manage their own locks
+    /// </summary>
+    NoLock = 0x400000,
 
-        /// <summary>
-        /// MDB_NORDAHEAD. don't do readahead (no effect on Windows)
-        /// </summary>
-        NoReadAhead = 0x800000,
+    /// <summary>
+    /// MDB_NORDAHEAD. don't do readahead (no effect on Windows)
+    /// </summary>
+    NoReadAhead = 0x800000,
 
-        /// <summary>
-        /// MDB_NOMEMINIT. don't initialize malloc'd memory before writing to datafile
-        /// </summary>
-        NoMemoryInitialization = 0x1000000
+    /// <summary>
+    /// MDB_NOMEMINIT. don't initialize malloc'd memory before writing to datafile
+    /// </summary>
+    NoMemoryInitialization = 0x1000000
 
-    }
 }

--- a/src/LightningDB/LightningCursor.cs
+++ b/src/LightningDB/LightningCursor.cs
@@ -4,532 +4,529 @@ using System.Runtime.CompilerServices;
 
 using static LightningDB.Native.Lmdb;
 
-namespace LightningDB
+namespace LightningDB;
+
+/// <summary>
+/// Cursor to iterate over a database
+/// </summary>
+public class LightningCursor : IDisposable
 {
+    private nint _handle;
+
     /// <summary>
-    /// Cursor to iterate over a database
+    /// Creates new instance of LightningCursor
     /// </summary>
-    public class LightningCursor : IDisposable
+    /// <param name="db">Database</param>
+    /// <param name="txn">Transaction</param>
+    internal LightningCursor(LightningDatabase db, LightningTransaction txn)
     {
-        private nint _handle;
+        if (db == null)
+            throw new ArgumentNullException(nameof(db));
 
-        /// <summary>
-        /// Creates new instance of LightningCursor
-        /// </summary>
-        /// <param name="db">Database</param>
-        /// <param name="txn">Transaction</param>
-        internal LightningCursor(LightningDatabase db, LightningTransaction txn)
-        {
-            if (db == null)
-                throw new ArgumentNullException(nameof(db));
+        if (txn == null)
+            throw new ArgumentNullException(nameof(txn));
 
-            if (txn == null)
-                throw new ArgumentNullException(nameof(txn));
+        mdb_cursor_open(txn.Handle(), db.Handle(), out _handle).ThrowOnError();
 
-            mdb_cursor_open(txn.Handle(), db.Handle(), out _handle).ThrowOnError();
+        Transaction = txn;
+        Transaction.Disposing += Dispose;
+    }
 
-            Transaction = txn;
-            Transaction.Disposing += Dispose;
-        }
+    /// <summary>
+    /// Gets the the native handle of the cursor
+    /// </summary>
+    public nint Handle()
+    {
+        return _handle;
+    }
 
-        /// <summary>
-        /// Gets the the native handle of the cursor
-        /// </summary>
-        public nint Handle()
-        {
-            return _handle;
-        }
+    /// <summary>
+    /// Cursor's transaction.
+    /// </summary>
+    public LightningTransaction Transaction { get; }
 
-        /// <summary>
-        /// Cursor's transaction.
-        /// </summary>
-        public LightningTransaction Transaction { get; }
-
-        /// <summary>
-        /// Position at specified key, if key is not found index will be positioned to closest match.
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <returns>Returns <see cref="MDBResultCode"/></returns>
-        public MDBResultCode Set(byte[] key)
-        {
-            return Get(CursorOperation.Set, key).resultCode;
-        }
+    /// <summary>
+    /// Position at specified key, if key is not found index will be positioned to closest match.
+    /// </summary>
+    /// <param name="key">Key</param>
+    /// <returns>Returns <see cref="MDBResultCode"/></returns>
+    public MDBResultCode Set(byte[] key)
+    {
+        return Get(CursorOperation.Set, key).resultCode;
+    }
         
-        /// <summary>
-        /// Position at specified key, if key is not found index will be positioned to closest match.
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <returns>Returns <see cref="MDBResultCode"/></returns>
-        public MDBResultCode Set(ReadOnlySpan<byte> key)
-        {
-            return Get(CursorOperation.Set, key).resultCode;
-        }
+    /// <summary>
+    /// Position at specified key, if key is not found index will be positioned to closest match.
+    /// </summary>
+    /// <param name="key">Key</param>
+    /// <returns>Returns <see cref="MDBResultCode"/></returns>
+    public MDBResultCode Set(ReadOnlySpan<byte> key)
+    {
+        return Get(CursorOperation.Set, key).resultCode;
+    }
 
-        /// <summary>
-        /// Moves to the key and populates Current with the values stored.
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <returns>Returns <see cref="MDBResultCode"/>, and <see cref="MDBValue"/> key/value</returns>
-        public (MDBResultCode resultCode, MDBValue key, MDBValue value) SetKey(byte[] key)
-        {
-            return Get(CursorOperation.SetKey, key);
-        }
+    /// <summary>
+    /// Moves to the key and populates Current with the values stored.
+    /// </summary>
+    /// <param name="key">Key</param>
+    /// <returns>Returns <see cref="MDBResultCode"/>, and <see cref="MDBValue"/> key/value</returns>
+    public (MDBResultCode resultCode, MDBValue key, MDBValue value) SetKey(byte[] key)
+    {
+        return Get(CursorOperation.SetKey, key);
+    }
         
-        /// <summary>
-        /// Moves to the key and populates Current with the values stored.
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <returns>Returns <see cref="MDBResultCode"/>, and <see cref="MDBValue"/> key/value</returns>
-        public (MDBResultCode resultCode, MDBValue key, MDBValue value) SetKey(ReadOnlySpan<byte> key)
-        {
-            return Get(CursorOperation.SetKey, key);
-        }
+    /// <summary>
+    /// Moves to the key and populates Current with the values stored.
+    /// </summary>
+    /// <param name="key">Key</param>
+    /// <returns>Returns <see cref="MDBResultCode"/>, and <see cref="MDBValue"/> key/value</returns>
+    public (MDBResultCode resultCode, MDBValue key, MDBValue value) SetKey(ReadOnlySpan<byte> key)
+    {
+        return Get(CursorOperation.SetKey, key);
+    }
 
-        /// <summary>
-        /// Position at key/data pair. Only for MDB_DUPSORT
-        /// </summary>
-        /// <param name="key">Key.</param>
-        /// <param name="value">Value</param>
-        /// <returns>Returns true if the key/value pair was found.</returns>
-        public MDBResultCode GetBoth(byte[] key, byte[] value)
-        {
-            return Get(CursorOperation.GetBoth, key, value).resultCode;
-        }
+    /// <summary>
+    /// Position at key/data pair. Only for MDB_DUPSORT
+    /// </summary>
+    /// <param name="key">Key.</param>
+    /// <param name="value">Value</param>
+    /// <returns>Returns true if the key/value pair was found.</returns>
+    public MDBResultCode GetBoth(byte[] key, byte[] value)
+    {
+        return Get(CursorOperation.GetBoth, key, value).resultCode;
+    }
         
-        /// <summary>
-        /// Position at key/data pair. Only for MDB_DUPSORT
-        /// </summary>
-        /// <param name="key">Key.</param>
-        /// <param name="value">Value</param>
-        /// <returns>Returns <see cref="MDBResultCode"/></returns>
-        public MDBResultCode GetBoth(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
-        {
-            return Get(CursorOperation.GetBoth, key, value).resultCode;
-        }
+    /// <summary>
+    /// Position at key/data pair. Only for MDB_DUPSORT
+    /// </summary>
+    /// <param name="key">Key.</param>
+    /// <param name="value">Value</param>
+    /// <returns>Returns <see cref="MDBResultCode"/></returns>
+    public MDBResultCode GetBoth(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
+    {
+        return Get(CursorOperation.GetBoth, key, value).resultCode;
+    }
 
-        /// <summary>
-        /// position at key, nearest data. Only for MDB_DUPSORT
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <param name="value">Value</param>
-        /// <returns>Returns <see cref="MDBResultCode"/></returns>
-        public MDBResultCode GetBothRange(byte[] key, byte[] value)
-        {
-            return Get(CursorOperation.GetBothRange, key, value).resultCode;
-        }
+    /// <summary>
+    /// position at key, nearest data. Only for MDB_DUPSORT
+    /// </summary>
+    /// <param name="key">Key</param>
+    /// <param name="value">Value</param>
+    /// <returns>Returns <see cref="MDBResultCode"/></returns>
+    public MDBResultCode GetBothRange(byte[] key, byte[] value)
+    {
+        return Get(CursorOperation.GetBothRange, key, value).resultCode;
+    }
         
-        /// <summary>
-        /// position at key, nearest data. Only for MDB_DUPSORT
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <param name="value">Value</param>
-        /// <returns>Returns <see cref="MDBResultCode"/></returns>
-        public MDBResultCode GetBothRange(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
-        {
-            return Get(CursorOperation.GetBothRange, key, value).resultCode;
-        }
+    /// <summary>
+    /// position at key, nearest data. Only for MDB_DUPSORT
+    /// </summary>
+    /// <param name="key">Key</param>
+    /// <param name="value">Value</param>
+    /// <returns>Returns <see cref="MDBResultCode"/></returns>
+    public MDBResultCode GetBothRange(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
+    {
+        return Get(CursorOperation.GetBothRange, key, value).resultCode;
+    }
 
-        /// <summary>
-        /// Position at first key greater than or equal to specified key.
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <returns>Returns <see cref="MDBResultCode"/></returns>
-        public MDBResultCode SetRange(byte[] key)
-        {
-            return Get(CursorOperation.SetRange, key).resultCode;
-        }
+    /// <summary>
+    /// Position at first key greater than or equal to specified key.
+    /// </summary>
+    /// <param name="key">Key</param>
+    /// <returns>Returns <see cref="MDBResultCode"/></returns>
+    public MDBResultCode SetRange(byte[] key)
+    {
+        return Get(CursorOperation.SetRange, key).resultCode;
+    }
         
-        /// <summary>
-        /// Position at first key greater than or equal to specified key.
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <returns>Returns <see cref="MDBResultCode"/></returns>
-        public MDBResultCode SetRange(ReadOnlySpan<byte> key)
-        {
-            return Get(CursorOperation.SetRange, key).resultCode;
-        }
+    /// <summary>
+    /// Position at first key greater than or equal to specified key.
+    /// </summary>
+    /// <param name="key">Key</param>
+    /// <returns>Returns <see cref="MDBResultCode"/></returns>
+    public MDBResultCode SetRange(ReadOnlySpan<byte> key)
+    {
+        return Get(CursorOperation.SetRange, key).resultCode;
+    }
 
-        /// <summary>
-        /// Position at first key/data item
-        /// </summary>
-        /// <returns>Returns <see cref="MDBResultCode"/></returns>
-        public MDBResultCode First()
-        {
-            return Get(CursorOperation.First).resultCode;
-        }
+    /// <summary>
+    /// Position at first key/data item
+    /// </summary>
+    /// <returns>Returns <see cref="MDBResultCode"/></returns>
+    public MDBResultCode First()
+    {
+        return Get(CursorOperation.First).resultCode;
+    }
 
-        /// <summary>
-        /// Position at first data item of current key. Only for MDB_DUPSORT
-        /// </summary>
-        /// <returns>Returns <see cref="MDBResultCode"/></returns>
-        public MDBResultCode FirstDuplicate()
-        {
-            return Get(CursorOperation.FirstDuplicate).resultCode;
-        }
+    /// <summary>
+    /// Position at first data item of current key. Only for MDB_DUPSORT
+    /// </summary>
+    /// <returns>Returns <see cref="MDBResultCode"/></returns>
+    public MDBResultCode FirstDuplicate()
+    {
+        return Get(CursorOperation.FirstDuplicate).resultCode;
+    }
 
-        /// <summary>
-        /// Position at last key/data item
-        /// </summary>
-        /// <returns>Returns <see cref="MDBResultCode"/></returns>
-        public MDBResultCode Last()
-        {
-            return Get(CursorOperation.Last).resultCode;
-        }
+    /// <summary>
+    /// Position at last key/data item
+    /// </summary>
+    /// <returns>Returns <see cref="MDBResultCode"/></returns>
+    public MDBResultCode Last()
+    {
+        return Get(CursorOperation.Last).resultCode;
+    }
 
-        /// <summary>
-        /// Position at last data item of current key. Only for MDB_DUPSORT
-        /// </summary>
-        /// <returns>Returns <see cref="MDBResultCode"/></returns>
-        public MDBResultCode LastDuplicate()
-        {
-            return Get(CursorOperation.LastDuplicate).resultCode;
-        }
+    /// <summary>
+    /// Position at last data item of current key. Only for MDB_DUPSORT
+    /// </summary>
+    /// <returns>Returns <see cref="MDBResultCode"/></returns>
+    public MDBResultCode LastDuplicate()
+    {
+        return Get(CursorOperation.LastDuplicate).resultCode;
+    }
 
-        /// <summary>
-        /// Return key/data at current cursor position
-        /// </summary>
-        /// <returns>Key/data at current cursor position</returns>
-        public (MDBResultCode resultCode, MDBValue key, MDBValue value) GetCurrent()
-        {
-            return Get(CursorOperation.GetCurrent);
-        }
+    /// <summary>
+    /// Return key/data at current cursor position
+    /// </summary>
+    /// <returns>Key/data at current cursor position</returns>
+    public (MDBResultCode resultCode, MDBValue key, MDBValue value) GetCurrent()
+    {
+        return Get(CursorOperation.GetCurrent);
+    }
 
-        /// <summary>
-        /// Position at next data item
-        /// </summary>
-        /// <returns>Returns <see cref="MDBResultCode"/></returns>
-        public MDBResultCode Next()
-        {
-            return Get(CursorOperation.Next).resultCode;
-        }
+    /// <summary>
+    /// Position at next data item
+    /// </summary>
+    /// <returns>Returns <see cref="MDBResultCode"/></returns>
+    public MDBResultCode Next()
+    {
+        return Get(CursorOperation.Next).resultCode;
+    }
 
-        /// <summary>
-        /// Position at next data item of current key. Only for MDB_DUPSORT
-        /// </summary>
-        /// <returns>Returns <see cref="MDBResultCode"/></returns>
-        public MDBResultCode NextDuplicate()
-        {
-            return Get(CursorOperation.NextDuplicate).resultCode;
-        }
+    /// <summary>
+    /// Position at next data item of current key. Only for MDB_DUPSORT
+    /// </summary>
+    /// <returns>Returns <see cref="MDBResultCode"/></returns>
+    public MDBResultCode NextDuplicate()
+    {
+        return Get(CursorOperation.NextDuplicate).resultCode;
+    }
 
-        /// <summary>
-        /// Position at first data item of next key. Only for MDB_DUPSORT.
-        /// </summary>
-        /// <returns>Returns <see cref="MDBResultCode"/></returns>
-        public MDBResultCode NextNoDuplicate()
-        {
-            return Get(CursorOperation.NextNoDuplicate).resultCode;
-        }
+    /// <summary>
+    /// Position at first data item of next key. Only for MDB_DUPSORT.
+    /// </summary>
+    /// <returns>Returns <see cref="MDBResultCode"/></returns>
+    public MDBResultCode NextNoDuplicate()
+    {
+        return Get(CursorOperation.NextNoDuplicate).resultCode;
+    }
 
-        /// <summary>
-        /// Return up to a page of duplicate data items at the next cursor position. Only for MDB_DUPFIXED
-        /// It is assumed you know the array size to break up a single byte[] into byte[][].
-        /// </summary>
-        /// <returns>Returns <see cref="MDBResultCode"/>, and <see cref="MDBValue"/> key will be empty here, values are 2D array</returns>
-        public (MDBResultCode resultCode, MDBValue key, MDBValue value) NextMultiple()
-        {
-            return Get(CursorOperation.NextMultiple);
-        }
+    /// <summary>
+    /// Return up to a page of duplicate data items at the next cursor position. Only for MDB_DUPFIXED
+    /// It is assumed you know the array size to break up a single byte[] into byte[][].
+    /// </summary>
+    /// <returns>Returns <see cref="MDBResultCode"/>, and <see cref="MDBValue"/> key will be empty here, values are 2D array</returns>
+    public (MDBResultCode resultCode, MDBValue key, MDBValue value) NextMultiple()
+    {
+        return Get(CursorOperation.NextMultiple);
+    }
 
-        /// <summary>
-        /// Position at previous data item.
-        /// </summary>
-        /// <returns>Returns <see cref="MDBResultCode"/></returns>
-        public MDBResultCode Previous()
-        {
-            return Get(CursorOperation.Previous).resultCode;
-        }
+    /// <summary>
+    /// Position at previous data item.
+    /// </summary>
+    /// <returns>Returns <see cref="MDBResultCode"/></returns>
+    public MDBResultCode Previous()
+    {
+        return Get(CursorOperation.Previous).resultCode;
+    }
 
-        /// <summary>
-        /// Position at previous data item of current key. Only for MDB_DUPSORT.
-        /// </summary>
-        /// <returns>Returns <see cref="MDBResultCode"/></returns>
-        public MDBResultCode PreviousDuplicate()
-        {
-            return Get(CursorOperation.PreviousDuplicate).resultCode;
-        }
+    /// <summary>
+    /// Position at previous data item of current key. Only for MDB_DUPSORT.
+    /// </summary>
+    /// <returns>Returns <see cref="MDBResultCode"/></returns>
+    public MDBResultCode PreviousDuplicate()
+    {
+        return Get(CursorOperation.PreviousDuplicate).resultCode;
+    }
 
-        /// <summary>
-        /// Position at last data item of previous key. Only for MDB_DUPSORT.
-        /// </summary>
-        /// <returns>Returns <see cref="MDBResultCode"/></returns>
-        public MDBResultCode PreviousNoDuplicate()
-        {
-            return Get(CursorOperation.PreviousNoDuplicate).resultCode;
-        }
+    /// <summary>
+    /// Position at last data item of previous key. Only for MDB_DUPSORT.
+    /// </summary>
+    /// <returns>Returns <see cref="MDBResultCode"/></returns>
+    public MDBResultCode PreviousNoDuplicate()
+    {
+        return Get(CursorOperation.PreviousNoDuplicate).resultCode;
+    }
         
-        private (MDBResultCode resultCode, MDBValue key, MDBValue value) Get(CursorOperation operation)
+    private (MDBResultCode resultCode, MDBValue key, MDBValue value) Get(CursorOperation operation)
+    {
+        var mdbKey = new MDBValue();
+        var mdbValue = new MDBValue();
+        return (mdb_cursor_get(_handle, ref mdbKey, ref mdbValue, operation), mdbKey, mdbValue);
+    }
+
+    private (MDBResultCode resultCode, MDBValue key, MDBValue value) Get(CursorOperation operation, byte[] key)
+    {
+        if (key is null)
+            throw new ArgumentNullException(nameof(key));
+
+        return Get(operation, key.AsSpan());
+    }
+
+    private unsafe (MDBResultCode resultCode, MDBValue key, MDBValue value) Get(CursorOperation operation, ReadOnlySpan<byte> key)
+    {
+        fixed (byte* keyPtr = key)
         {
-            var mdbKey = new MDBValue();
+            var mdbKey = new MDBValue(key.Length, keyPtr);
             var mdbValue = new MDBValue();
             return (mdb_cursor_get(_handle, ref mdbKey, ref mdbValue, operation), mdbKey, mdbValue);
         }
+    }
 
-        private (MDBResultCode resultCode, MDBValue key, MDBValue value) Get(CursorOperation operation, byte[] key)
+    private (MDBResultCode resultCode, MDBValue key, MDBValue value) Get(CursorOperation operation, byte[] key, byte[] value)
+    {
+        return Get(operation, key.AsSpan(), value.AsSpan());
+    }
+
+    private unsafe (MDBResultCode resultCode, MDBValue key, MDBValue value) Get(CursorOperation operation, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
+    {
+        fixed(byte* keyPtr = key)
+        fixed(byte* valPtr = value)
         {
-            if (key is null)
-                throw new ArgumentNullException(nameof(key));
+            var mdbKey = new MDBValue(key.Length, keyPtr);
+            var mdbValue = new MDBValue(value.Length, valPtr);
+            return (mdb_cursor_get(_handle, ref mdbKey, ref mdbValue, operation), mdbKey, mdbValue);
+        }
+    }
 
-            return Get(operation, key.AsSpan());
+    /// <summary>
+    /// Store by cursor.
+    /// This function stores key/data pairs into the database. The cursor is positioned at the new item, or on failure usually near it.
+    /// Note: Earlier documentation incorrectly said errors would leave the state of the cursor unchanged.
+    /// If the function fails for any reason, the state of the cursor will be unchanged. 
+    /// If the function succeeds and an item is inserted into the database, the cursor is always positioned to refer to the newly inserted item.
+    /// </summary>
+    /// <param name="key">The key operated on.</param>
+    /// <param name="value">The data operated on.</param>
+    /// <param name="options">
+    /// Options for this operation. This parameter must be set to 0 or one of the values described here.
+    ///     CursorPutOptions.Current - overwrite the data of the key/data pair to which the cursor refers with the specified data item. The key parameter is ignored.
+    ///     CursorPutOptions.NoDuplicateData - enter the new key/data pair only if it does not already appear in the database. This flag may only be specified if the database was opened with MDB_DUPSORT. The function will return MDB_KEYEXIST if the key/data pair already appears in the database.
+    ///     CursorPutOptions.NoOverwrite - enter the new key/data pair only if the key does not already appear in the database. The function will return MDB_KEYEXIST if the key already appears in the database, even if the database supports duplicates (MDB_DUPSORT).
+    ///     CursorPutOptions.ReserveSpace - reserve space for data of the given size, but don't copy the given data. Instead, return a pointer to the reserved space, which the caller can fill in later. This saves an extra memcpy if the data is being generated later.
+    ///     CursorPutOptions.AppendData - append the given key/data pair to the end of the database. No key comparisons are performed. This option allows fast bulk loading when keys are already known to be in the correct order. Loading unsorted keys with this flag will cause data corruption.
+    ///     CursorPutOptions.AppendDuplicateData - as above, but for sorted dup data.
+    /// </param>
+    /// <returns>Returns <see cref="MDBResultCode"/></returns>
+    public MDBResultCode Put(byte[] key, byte[] value, CursorPutOptions options)
+    {
+        return Put(key.AsSpan(), value.AsSpan(), options);
+    }
+
+
+    /// <summary>
+    /// Store by cursor.
+    /// This function stores key/data pairs into the database. The cursor is positioned at the new item, or on failure usually near it.
+    /// Note: Earlier documentation incorrectly said errors would leave the state of the cursor unchanged.
+    /// If the function fails for any reason, the state of the cursor will be unchanged. 
+    /// If the function succeeds and an item is inserted into the database, the cursor is always positioned to refer to the newly inserted item.
+    /// </summary>
+    /// <param name="key">The key operated on.</param>
+    /// <param name="value">The data operated on.</param>
+    /// <param name="options">
+    /// Options for this operation. This parameter must be set to 0 or one of the values described here.
+    ///     CursorPutOptions.Current - overwrite the data of the key/data pair to which the cursor refers with the specified data item. The key parameter is ignored.
+    ///     CursorPutOptions.NoDuplicateData - enter the new key/data pair only if it does not already appear in the database. This flag may only be specified if the database was opened with MDB_DUPSORT. The function will return MDB_KEYEXIST if the key/data pair already appears in the database.
+    ///     CursorPutOptions.NoOverwrite - enter the new key/data pair only if the key does not already appear in the database. The function will return MDB_KEYEXIST if the key already appears in the database, even if the database supports duplicates (MDB_DUPSORT).
+    ///     CursorPutOptions.ReserveSpace - reserve space for data of the given size, but don't copy the given data. Instead, return a pointer to the reserved space, which the caller can fill in later. This saves an extra memcpy if the data is being generated later.
+    ///     CursorPutOptions.AppendData - append the given key/data pair to the end of the database. No key comparisons are performed. This option allows fast bulk loading when keys are already known to be in the correct order. Loading unsorted keys with this flag will cause data corruption.
+    ///     CursorPutOptions.AppendDuplicateData - as above, but for sorted dup data.
+    /// </param>
+    /// <returns>Returns <see cref="MDBResultCode"/></returns>
+    public unsafe MDBResultCode Put(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, CursorPutOptions options)
+    {
+        fixed (byte* keyPtr = key)
+        fixed (byte* valPtr = value)
+        {
+            var mdbKey = new MDBValue(key.Length, keyPtr);
+            var mdbValue = new MDBValue(value.Length, valPtr);
+
+            return mdb_cursor_put(_handle, mdbKey, mdbValue, options);
+        }
+    }
+
+    /// <summary>
+    /// Store by cursor.
+    /// This function stores key/data pairs into the database. 
+    /// If the function fails for any reason, the state of the cursor will be unchanged. 
+    /// If the function succeeds and an item is inserted into the database, the cursor is always positioned to refer to the newly inserted item.
+    /// </summary>
+    /// <param name="key">The key operated on.</param>
+    /// <param name="values">The data items operated on.</param>
+    /// <returns>Returns <see cref="MDBResultCode"/></returns>
+    public unsafe MDBResultCode Put(byte[] key, byte[][] values)
+    {
+        const int StackAllocateLimit = 256;//I just made up a number, this can be much more aggressive -arc
+
+        var overallLength = values.Sum(arr => arr.Length);//probably allocates but boy is it handy...
+
+
+        //the idea here is to gain some perf by stackallocating the buffer to 
+        //hold the contiguous keys
+        if (overallLength < StackAllocateLimit)
+        {
+            Span<byte> contiguousValues = stackalloc byte[overallLength];
+
+            return InnerPutMultiple(contiguousValues);
         }
 
-        private unsafe (MDBResultCode resultCode, MDBValue key, MDBValue value) Get(CursorOperation operation, ReadOnlySpan<byte> key)
+        fixed (byte* contiguousValuesPtr = new byte[overallLength])
         {
+            var contiguousValues = new Span<byte>(contiguousValuesPtr, overallLength);
+            return InnerPutMultiple(contiguousValues);
+        }
+
+        //these local methods could be made static, but the compiler will emit these closures
+        //as structs with very little overhead. Also static local functions isn't available 
+        //until C# 8 so I can't use it anyway...
+        MDBResultCode InnerPutMultiple(Span<byte> contiguousValuesBuffer)
+        {
+            FlattenInfo(contiguousValuesBuffer);
+            var contiguousValuesPtr = (byte*)Unsafe.AsPointer(ref contiguousValuesBuffer.GetPinnableReference());
+
+            var mdbValue = new MDBValue(GetSize(), contiguousValuesPtr);
+            var mdbCount = new MDBValue(values.Length, null);
+
+            Span<MDBValue> dataBuffer = stackalloc MDBValue[2] { mdbValue, mdbCount };
+
             fixed (byte* keyPtr = key)
             {
                 var mdbKey = new MDBValue(key.Length, keyPtr);
-                var mdbValue = new MDBValue();
-                return (mdb_cursor_get(_handle, ref mdbKey, ref mdbValue, operation), mdbKey, mdbValue);
+
+                return mdb_cursor_put(_handle, ref mdbKey, ref dataBuffer, CursorPutOptions.MultipleData);
             }
         }
 
-        private (MDBResultCode resultCode, MDBValue key, MDBValue value) Get(CursorOperation operation, byte[] key, byte[] value)
+        void FlattenInfo(Span<byte> targetBuffer)
         {
-            return Get(operation, key.AsSpan(), value.AsSpan());
-        }
+            var cursor = targetBuffer;
 
-        private unsafe (MDBResultCode resultCode, MDBValue key, MDBValue value) Get(CursorOperation operation, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
-        {
-            fixed(byte* keyPtr = key)
-            fixed(byte* valPtr = value)
+            foreach(var buffer in values)
             {
-                var mdbKey = new MDBValue(key.Length, keyPtr);
-                var mdbValue = new MDBValue(value.Length, valPtr);
-                return (mdb_cursor_get(_handle, ref mdbKey, ref mdbValue, operation), mdbKey, mdbValue);
+                buffer.CopyTo(cursor);
+                cursor = cursor.Slice(buffer.Length);
             }
         }
 
-        /// <summary>
-        /// Store by cursor.
-        /// This function stores key/data pairs into the database. The cursor is positioned at the new item, or on failure usually near it.
-        /// Note: Earlier documentation incorrectly said errors would leave the state of the cursor unchanged.
-        /// If the function fails for any reason, the state of the cursor will be unchanged. 
-        /// If the function succeeds and an item is inserted into the database, the cursor is always positioned to refer to the newly inserted item.
-        /// </summary>
-        /// <param name="key">The key operated on.</param>
-        /// <param name="value">The data operated on.</param>
-        /// <param name="options">
-        /// Options for this operation. This parameter must be set to 0 or one of the values described here.
-        ///     CursorPutOptions.Current - overwrite the data of the key/data pair to which the cursor refers with the specified data item. The key parameter is ignored.
-        ///     CursorPutOptions.NoDuplicateData - enter the new key/data pair only if it does not already appear in the database. This flag may only be specified if the database was opened with MDB_DUPSORT. The function will return MDB_KEYEXIST if the key/data pair already appears in the database.
-        ///     CursorPutOptions.NoOverwrite - enter the new key/data pair only if the key does not already appear in the database. The function will return MDB_KEYEXIST if the key already appears in the database, even if the database supports duplicates (MDB_DUPSORT).
-        ///     CursorPutOptions.ReserveSpace - reserve space for data of the given size, but don't copy the given data. Instead, return a pointer to the reserved space, which the caller can fill in later. This saves an extra memcpy if the data is being generated later.
-        ///     CursorPutOptions.AppendData - append the given key/data pair to the end of the database. No key comparisons are performed. This option allows fast bulk loading when keys are already known to be in the correct order. Loading unsorted keys with this flag will cause data corruption.
-        ///     CursorPutOptions.AppendDuplicateData - as above, but for sorted dup data.
-        /// </param>
-        /// <returns>Returns <see cref="MDBResultCode"/></returns>
-        public MDBResultCode Put(byte[] key, byte[] value, CursorPutOptions options)
+        int GetSize() 
         {
-            return Put(key.AsSpan(), value.AsSpan(), options);
+            if (values.Length == 0 || values[0] == null || values[0].Length == 0)
+                return 0;
+
+            return values[0].Length;
         }
+    }
 
+    /// <summary>
+    /// Return up to a page of the duplicate data items at the current cursor position. Only for MDB_DUPFIXED
+    /// It is assumed you know the array size to break up a single byte[] into byte[][].
+    /// </summary>
+    /// <returns>Returns <see cref="MDBResultCode"/>, and <see cref="MDBValue"/> key will be empty here, values are 2D array</returns>
+    public (MDBResultCode resultCode, MDBValue key, MDBValue value) GetMultiple()
+    {
+        return Get(CursorOperation.GetMultiple);
+    }
 
-        /// <summary>
-        /// Store by cursor.
-        /// This function stores key/data pairs into the database. The cursor is positioned at the new item, or on failure usually near it.
-        /// Note: Earlier documentation incorrectly said errors would leave the state of the cursor unchanged.
-        /// If the function fails for any reason, the state of the cursor will be unchanged. 
-        /// If the function succeeds and an item is inserted into the database, the cursor is always positioned to refer to the newly inserted item.
-        /// </summary>
-        /// <param name="key">The key operated on.</param>
-        /// <param name="value">The data operated on.</param>
-        /// <param name="options">
-        /// Options for this operation. This parameter must be set to 0 or one of the values described here.
-        ///     CursorPutOptions.Current - overwrite the data of the key/data pair to which the cursor refers with the specified data item. The key parameter is ignored.
-        ///     CursorPutOptions.NoDuplicateData - enter the new key/data pair only if it does not already appear in the database. This flag may only be specified if the database was opened with MDB_DUPSORT. The function will return MDB_KEYEXIST if the key/data pair already appears in the database.
-        ///     CursorPutOptions.NoOverwrite - enter the new key/data pair only if the key does not already appear in the database. The function will return MDB_KEYEXIST if the key already appears in the database, even if the database supports duplicates (MDB_DUPSORT).
-        ///     CursorPutOptions.ReserveSpace - reserve space for data of the given size, but don't copy the given data. Instead, return a pointer to the reserved space, which the caller can fill in later. This saves an extra memcpy if the data is being generated later.
-        ///     CursorPutOptions.AppendData - append the given key/data pair to the end of the database. No key comparisons are performed. This option allows fast bulk loading when keys are already known to be in the correct order. Loading unsorted keys with this flag will cause data corruption.
-        ///     CursorPutOptions.AppendDuplicateData - as above, but for sorted dup data.
-        /// </param>
-        /// <returns>Returns <see cref="MDBResultCode"/></returns>
-        public unsafe MDBResultCode Put(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, CursorPutOptions options)
-        {
-            fixed (byte* keyPtr = key)
-            fixed (byte* valPtr = value)
-            {
-                var mdbKey = new MDBValue(key.Length, keyPtr);
-                var mdbValue = new MDBValue(value.Length, valPtr);
+    /// <summary>
+    /// Delete current key/data pair.
+    /// This function deletes the key/data pair to which the cursor refers.
+    /// </summary>
+    /// <param name="option">Options for this operation. This parameter must be set to 0 or one of the values described here.
+    ///     MDB_NODUPDATA - delete all of the data items for the current key. This flag may only be specified if the database was opened with MDB_DUPSORT.</param>
+    private MDBResultCode Delete(CursorDeleteOption option)
+    {
+        return mdb_cursor_del(_handle, option);
+    }
 
-                return mdb_cursor_put(_handle, mdbKey, mdbValue, options);
-            }
-        }
+    /// <summary>
+    /// Delete current key/data pair.
+    /// This function deletes the key/data range for which duplicates are found.
+    /// </summary>
+    public MDBResultCode DeleteDuplicateData()
+    {
+        return Delete(CursorDeleteOption.NoDuplicateData);
+    }
 
-        /// <summary>
-        /// Store by cursor.
-        /// This function stores key/data pairs into the database. 
-        /// If the function fails for any reason, the state of the cursor will be unchanged. 
-        /// If the function succeeds and an item is inserted into the database, the cursor is always positioned to refer to the newly inserted item.
-        /// </summary>
-        /// <param name="key">The key operated on.</param>
-        /// <param name="values">The data items operated on.</param>
-        /// <returns>Returns <see cref="MDBResultCode"/></returns>
-        public unsafe MDBResultCode Put(byte[] key, byte[][] values)
-        {
-            const int StackAllocateLimit = 256;//I just made up a number, this can be much more aggressive -arc
+    /// <summary>
+    /// Delete current key/data pair.
+    /// This function deletes the key/data pair to which the cursor refers.
+    /// </summary>
+    public MDBResultCode Delete()
+    {
+        return Delete(CursorDeleteOption.None);
+    }
 
-            int overallLength = values.Sum(arr => arr.Length);//probably allocates but boy is it handy...
+    /// <summary>
+    /// Renew a cursor handle.
+    /// Cursors are associated with a specific transaction and database and may not span threads. 
+    /// Cursors that are only used in read-only transactions may be re-used, to avoid unnecessary malloc/free overhead. 
+    /// The cursor may be associated with a new read-only transaction, and referencing the same database handle as it was created with.
+    /// </summary>
+    /// <returns>Returns <see cref="MDBResultCode"/></returns>
+    public MDBResultCode Renew()
+    {
+        return Renew(Transaction);
+    }
 
+    /// <summary>
+    /// Renew a cursor handle.
+    /// Cursors are associated with a specific transaction and database and may not span threads. 
+    /// Cursors that are only used in read-only transactions may be re-used, to avoid unnecessary malloc/free overhead. 
+    /// The cursor may be associated with a new read-only transaction, and referencing the same database handle as it was created with.
+    /// </summary>
+    /// <param name="txn">Transaction to renew in.</param>
+    /// <returns>Returns <see cref="MDBResultCode"/></returns>
+    public MDBResultCode Renew(LightningTransaction txn)
+    {
+        if(txn == null)
+            throw new ArgumentNullException(nameof(txn));
 
-            //the idea here is to gain some perf by stackallocating the buffer to 
-            //hold the contiguous keys
-            if (overallLength < StackAllocateLimit)
-            {
-                Span<byte> contiguousValues = stackalloc byte[overallLength];
+        if (!txn.IsReadOnly)
+            throw new InvalidOperationException("Can't renew cursor on non-readonly transaction");
 
-                return InnerPutMultiple(contiguousValues);
-            }
-            else
-            {
-                fixed (byte* contiguousValuesPtr = new byte[overallLength])
-                {
-                    Span<byte> contiguousValues = new Span<byte>(contiguousValuesPtr, overallLength);
-                    return InnerPutMultiple(contiguousValues);
-                }
-            }
+        return mdb_cursor_renew(txn.Handle(), _handle);
+    }
 
-            //these local methods could be made static, but the compiler will emit these closures
-            //as structs with very little overhead. Also static local functions isn't available 
-            //until C# 8 so I can't use it anyway...
-            MDBResultCode InnerPutMultiple(Span<byte> contiguousValuesBuffer)
-            {
-                FlattenInfo(contiguousValuesBuffer);
-                var contiguousValuesPtr = (byte*)Unsafe.AsPointer(ref contiguousValuesBuffer.GetPinnableReference());
+    /// <summary>
+    /// Closes the cursor and deallocates all resources associated with it.
+    /// </summary>
+    /// <param name="disposing">True if called from Dispose.</param>
+    private void Dispose(bool disposing)
+    {
+        if (_handle == 0)
+            return;
 
-                var mdbValue = new MDBValue(GetSize(), contiguousValuesPtr);
-                var mdbCount = new MDBValue(values.Length, (byte*)null);
+        if (!disposing)
+            throw new InvalidOperationException("The LightningCursor was not disposed and cannot be reliably dealt with from the finalizer");
 
-                Span<MDBValue> dataBuffer = stackalloc MDBValue[2] { mdbValue, mdbCount };
+        mdb_cursor_close(_handle);
+        _handle = 0;
 
-                fixed (byte* keyPtr = key)
-                {
-                    var mdbKey = new MDBValue(key.Length, keyPtr);
+        Transaction.Disposing -= Dispose;
 
-                    return mdb_cursor_put(_handle, ref mdbKey, ref dataBuffer, CursorPutOptions.MultipleData);
-                }
-            }
+        GC.SuppressFinalize(this);
+    }
 
-            void FlattenInfo(Span<byte> targetBuffer)
-            {
-                var cursor = targetBuffer;
+    /// <summary>
+    /// Closes the cursor and deallocates all resources associated with it.
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+    }
 
-                foreach(var buffer in values)
-                {
-                    buffer.CopyTo(cursor);
-                    cursor = cursor.Slice(buffer.Length);
-                }
-            }
-
-            int GetSize() 
-            {
-                if (values.Length == 0 || values[0] == null || values[0].Length == 0)
-                    return 0;
-
-                return values[0].Length;
-            }
-        }
-
-        /// <summary>
-        /// Return up to a page of the duplicate data items at the current cursor position. Only for MDB_DUPFIXED
-        /// It is assumed you know the array size to break up a single byte[] into byte[][].
-        /// </summary>
-        /// <returns>Returns <see cref="MDBResultCode"/>, and <see cref="MDBValue"/> key will be empty here, values are 2D array</returns>
-        public (MDBResultCode resultCode, MDBValue key, MDBValue value) GetMultiple()
-        {
-            return Get(CursorOperation.GetMultiple);
-        }
-
-        /// <summary>
-        /// Delete current key/data pair.
-        /// This function deletes the key/data pair to which the cursor refers.
-        /// </summary>
-        /// <param name="option">Options for this operation. This parameter must be set to 0 or one of the values described here.
-        ///     MDB_NODUPDATA - delete all of the data items for the current key. This flag may only be specified if the database was opened with MDB_DUPSORT.</param>
-        private MDBResultCode Delete(CursorDeleteOption option)
-        {
-            return mdb_cursor_del(_handle, option);
-        }
-
-        /// <summary>
-        /// Delete current key/data pair.
-        /// This function deletes the key/data range for which duplicates are found.
-        /// </summary>
-        public MDBResultCode DeleteDuplicateData()
-        {
-            return Delete(CursorDeleteOption.NoDuplicateData);
-        }
-
-        /// <summary>
-        /// Delete current key/data pair.
-        /// This function deletes the key/data pair to which the cursor refers.
-        /// </summary>
-        public MDBResultCode Delete()
-        {
-            return Delete(CursorDeleteOption.None);
-        }
-
-        /// <summary>
-        /// Renew a cursor handle.
-        /// Cursors are associated with a specific transaction and database and may not span threads. 
-        /// Cursors that are only used in read-only transactions may be re-used, to avoid unnecessary malloc/free overhead. 
-        /// The cursor may be associated with a new read-only transaction, and referencing the same database handle as it was created with.
-        /// </summary>
-        /// <returns>Returns <see cref="MDBResultCode"/></returns>
-        public MDBResultCode Renew()
-        {
-            return Renew(Transaction);
-        }
-
-        /// <summary>
-        /// Renew a cursor handle.
-        /// Cursors are associated with a specific transaction and database and may not span threads. 
-        /// Cursors that are only used in read-only transactions may be re-used, to avoid unnecessary malloc/free overhead. 
-        /// The cursor may be associated with a new read-only transaction, and referencing the same database handle as it was created with.
-        /// </summary>
-        /// <param name="txn">Transaction to renew in.</param>
-        /// <returns>Returns <see cref="MDBResultCode"/></returns>
-        public MDBResultCode Renew(LightningTransaction txn)
-        {
-            if(txn == null)
-                throw new ArgumentNullException(nameof(txn));
-
-            if (!txn.IsReadOnly)
-                throw new InvalidOperationException("Can't renew cursor on non-readonly transaction");
-
-            return mdb_cursor_renew(txn.Handle(), _handle);
-        }
-
-        /// <summary>
-        /// Closes the cursor and deallocates all resources associated with it.
-        /// </summary>
-        /// <param name="disposing">True if called from Dispose.</param>
-        private void Dispose(bool disposing)
-        {
-            if (_handle == IntPtr.Zero)
-                return;
-
-            if (!disposing)
-                throw new InvalidOperationException("The LightningCursor was not disposed and cannot be reliably dealt with from the finalizer");
-
-            mdb_cursor_close(_handle);
-            _handle = IntPtr.Zero;
-
-            Transaction.Disposing -= Dispose;
-
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Closes the cursor and deallocates all resources associated with it.
-        /// </summary>
-        public void Dispose()
-        {
-            Dispose(true);
-        }
-
-        ~LightningCursor()
-        {
-            Dispose(false);
-        }
+    ~LightningCursor()
+    {
+        Dispose(false);
     }
 }

--- a/src/LightningDB/LightningCursor.cs
+++ b/src/LightningDB/LightningCursor.cs
@@ -11,7 +11,7 @@ namespace LightningDB
     /// </summary>
     public class LightningCursor : IDisposable
     {
-        private IntPtr _handle;
+        private nint _handle;
 
         /// <summary>
         /// Creates new instance of LightningCursor
@@ -35,7 +35,7 @@ namespace LightningDB
         /// <summary>
         /// Gets the the native handle of the cursor
         /// </summary>
-        public IntPtr Handle()
+        public nint Handle()
         {
             return _handle;
         }

--- a/src/LightningDB/LightningDB.csproj
+++ b/src/LightningDB/LightningDB.csproj
@@ -29,6 +29,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
 </Project>

--- a/src/LightningDB/LightningDB.csproj
+++ b/src/LightningDB/LightningDB.csproj
@@ -4,7 +4,8 @@
     <Description>LightningDB</Description>
     <VersionPrefix>0.14.1</VersionPrefix>
     <Authors>Ilya Lukyanov;Corey Kaylor</Authors>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net7.0</TargetFrameworks>
+    <LangVersion>11</LangVersion>
     <AssemblyName>LightningDB</AssemblyName>
     <PackageId>LightningDB</PackageId>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/LightningDB/LightningDatabase.cs
+++ b/src/LightningDB/LightningDatabase.cs
@@ -60,11 +60,11 @@ namespace LightningDB
                 mdb_stat(_transaction.Handle(), Handle(), out var nativeStat).ThrowOnError();
                 return new Stats
                 {
-                    BranchPages = nativeStat.ms_branch_pages.ToInt64(),
+                    BranchPages = nativeStat.ms_branch_pages,
                     BTreeDepth = nativeStat.ms_depth,
-                    Entries = nativeStat.ms_entries.ToInt64(),
-                    LeafPages = nativeStat.ms_leaf_pages.ToInt64(),
-                    OverflowPages = nativeStat.ms_overflow_pages.ToInt64(),
+                    Entries = nativeStat.ms_entries,
+                    LeafPages = nativeStat.ms_leaf_pages,
+                    OverflowPages = nativeStat.ms_overflow_pages,
                     PageSize = nativeStat.ms_psize
                 };
             }

--- a/src/LightningDB/LightningDatabase.cs
+++ b/src/LightningDB/LightningDatabase.cs
@@ -1,138 +1,137 @@
 ﻿using System;
 using static LightningDB.Native.Lmdb;
 
-namespace LightningDB
+namespace LightningDB;
+
+/// <summary>
+/// Lightning database.
+/// </summary>
+public sealed class LightningDatabase : IDisposable
 {
+    private uint _handle;
+    private readonly DatabaseConfiguration _configuration;
+    private readonly bool _closeOnDispose;
+    private readonly LightningTransaction _transaction;
+    private readonly IDisposable _pinnedConfig;
+
     /// <summary>
-    /// Lightning database.
+    /// Creates a LightningDatabase instance.
     /// </summary>
-    public sealed class LightningDatabase : IDisposable
+    /// <param name="name">Database name.</param>
+    /// <param name="transaction">Active transaction.</param>
+    /// <param name="configuration">Options for the database, like encoding, option flags, and comparison logic.</param>
+    /// <param name="closeOnDispose">Close database handle on dispose</param>
+    internal LightningDatabase(string name, LightningTransaction transaction, DatabaseConfiguration configuration,
+        bool closeOnDispose)
     {
-        private uint _handle;
-        private readonly DatabaseConfiguration _configuration;
-        private readonly bool _closeOnDispose;
-        private readonly LightningTransaction _transaction;
-        private readonly IDisposable _pinnedConfig;
+        if (transaction == null)
+            throw new ArgumentNullException(nameof(transaction));
 
-        /// <summary>
-        /// Creates a LightningDatabase instance.
-        /// </summary>
-        /// <param name="name">Database name.</param>
-        /// <param name="transaction">Active transaction.</param>
-        /// <param name="configuration">Options for the database, like encoding, option flags, and comparison logic.</param>
-        /// <param name="closeOnDispose">Close database handle on dispose</param>
-        internal LightningDatabase(string name, LightningTransaction transaction, DatabaseConfiguration configuration,
-            bool closeOnDispose)
+        Name = name;
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _closeOnDispose = closeOnDispose;
+        Environment = transaction.Environment;
+        _transaction = transaction;
+        Environment.Disposing += Dispose;
+        mdb_dbi_open(transaction.Handle(), name, _configuration.Flags, out _handle).ThrowOnError();
+        _pinnedConfig = _configuration.ConfigureDatabase(transaction, this);
+        IsOpened = true;
+    }
+
+    public uint Handle()
+    {
+        return _handle;
+    }
+
+    /// <summary>
+    /// Whether the database handle has been release from Dispose, or from unsuccessful OpenDatabase call.
+    /// </summary>
+    public bool IsReleased => _handle == default;
+
+    /// <summary>
+    /// Is database opened.
+    /// </summary>
+    public bool IsOpened { get; private set; }
+
+    public Stats DatabaseStats
+    {
+        get
         {
-            if (transaction == null)
-                throw new ArgumentNullException(nameof(transaction));
-
-            Name = name;
-            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
-            _closeOnDispose = closeOnDispose;
-            Environment = transaction.Environment;
-            _transaction = transaction;
-            Environment.Disposing += Dispose;
-            mdb_dbi_open(transaction.Handle(), name, _configuration.Flags, out _handle).ThrowOnError();
-            _pinnedConfig = _configuration.ConfigureDatabase(transaction, this);
-            IsOpened = true;
-        }
-
-        public uint Handle()
-        {
-            return _handle;
-        }
-
-        /// <summary>
-        /// Whether the database handle has been release from Dispose, or from unsuccessful OpenDatabase call.
-        /// </summary>
-        public bool IsReleased => _handle == default;
-
-        /// <summary>
-        /// Is database opened.
-        /// </summary>
-        public bool IsOpened { get; private set; }
-
-        public Stats DatabaseStats
-        {
-            get
+            mdb_stat(_transaction.Handle(), Handle(), out var nativeStat).ThrowOnError();
+            return new Stats
             {
-                mdb_stat(_transaction.Handle(), Handle(), out var nativeStat).ThrowOnError();
-                return new Stats
-                {
-                    BranchPages = nativeStat.ms_branch_pages,
-                    BTreeDepth = nativeStat.ms_depth,
-                    Entries = nativeStat.ms_entries,
-                    LeafPages = nativeStat.ms_leaf_pages,
-                    OverflowPages = nativeStat.ms_overflow_pages,
-                    PageSize = nativeStat.ms_psize
-                };
-            }
+                BranchPages = nativeStat.ms_branch_pages,
+                BTreeDepth = nativeStat.ms_depth,
+                Entries = nativeStat.ms_entries,
+                LeafPages = nativeStat.ms_leaf_pages,
+                OverflowPages = nativeStat.ms_overflow_pages,
+                PageSize = nativeStat.ms_psize
+            };
         }
+    }
 
-        /// <summary>
-        /// Database name.
-        /// </summary>
-        public string Name { get; }
+    /// <summary>
+    /// Database name.
+    /// </summary>
+    public string Name { get; }
 
-        /// <summary>
-        /// Environment in which the database was opened.
-        /// </summary>
-        public LightningEnvironment Environment { get; }
+    /// <summary>
+    /// Environment in which the database was opened.
+    /// </summary>
+    public LightningEnvironment Environment { get; }
 
-        /// <summary>
-        /// Drops the database.
-        /// </summary>
-        public MDBResultCode Drop(LightningTransaction transaction)
-        {
-            var result = mdb_drop(transaction.Handle(), _handle, true);
-            IsOpened = false;
-            _handle = default;
-            return result;
-        }
+    /// <summary>
+    /// Drops the database.
+    /// </summary>
+    public MDBResultCode Drop(LightningTransaction transaction)
+    {
+        var result = mdb_drop(transaction.Handle(), _handle, true);
+        IsOpened = false;
+        _handle = default;
+        return result;
+    }
 
-        /// <summary>
-        /// Truncates all data from the database.
-        /// </summary>
-        public MDBResultCode Truncate(LightningTransaction transaction)
-        {
-            return mdb_drop(transaction.Handle(), _handle, false);
-        }
+    /// <summary>
+    /// Truncates all data from the database.
+    /// </summary>
+    public MDBResultCode Truncate(LightningTransaction transaction)
+    {
+        return mdb_drop(transaction.Handle(), _handle, false);
+    }
 
-        /// <summary>
-        /// Deallocates resources opened by the database.
-        /// </summary>
-        /// <param name="disposing">true if called from Dispose.</param>
-        private void Dispose(bool disposing)
-        {
-            if (_handle == default)
-                return;
+    /// <summary>
+    /// Deallocates resources opened by the database.
+    /// </summary>
+    /// <param name="disposing">true if called from Dispose.</param>
+    private void Dispose(bool disposing)
+    {
+        if (_handle == default)
+            return;
 
-            if(!disposing)
-                throw new InvalidOperationException("The LightningDatabase was not disposed and cannot be reliably dealt with from the finalizer");
+        if(!disposing)
+            throw new InvalidOperationException("The LightningDatabase was not disposed and cannot be reliably dealt with from the finalizer");
 
-            Environment.Disposing -= Dispose;
-            IsOpened = false;
-            _pinnedConfig.Dispose();
+        Environment.Disposing -= Dispose;
+        IsOpened = false;
+        _pinnedConfig.Dispose();
 
-            if (_closeOnDispose)
-                mdb_dbi_close(Environment.Handle(), _handle);
+        if (_closeOnDispose)
+            mdb_dbi_close(Environment.Handle(), _handle);
 
-            GC.SuppressFinalize(this);
-            _handle = default;
-        }
+        GC.SuppressFinalize(this);
+        _handle = default;
+    }
 
-        /// <summary>
-        /// Deallocates resources opened by the database.
-        /// </summary>
-        public void Dispose()
-        {
-            Dispose(true);
-        }
+    /// <summary>
+    /// Deallocates resources opened by the database.
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+    }
 
-        ~LightningDatabase()
-        {
-            Dispose(false);
-        }
+    ~LightningDatabase()
+    {
+        Dispose(false);
     }
 }

--- a/src/LightningDB/LightningEnvironment.cs
+++ b/src/LightningDB/LightningEnvironment.cs
@@ -2,317 +2,315 @@
 using System.IO;
 using static LightningDB.Native.Lmdb;
 
-namespace LightningDB
+namespace LightningDB;
+
+/// <summary>
+/// LMDB Environment.
+/// </summary>
+public sealed class LightningEnvironment : IDisposable
 {
+    private readonly EnvironmentConfiguration _config = new();
+
+    private nint _handle;
+
+    public event Action Disposing;
+
     /// <summary>
-    /// LMDB Environment.
+    /// Creates a new instance of LightningEnvironment.
     /// </summary>
-    public sealed class LightningEnvironment : IDisposable
+    /// <param name="path">Directory for storing database files.</param>
+    /// <param name="configuration">Configuration for the environment.</param>
+    public LightningEnvironment(string path, EnvironmentConfiguration configuration = null)
     {
-        private readonly EnvironmentConfiguration _config = new EnvironmentConfiguration();
-
-        private nint _handle;
-
-        public event Action Disposing;
-
-        /// <summary>
-        /// Creates a new instance of LightningEnvironment.
-        /// </summary>
-        /// <param name="path">Directory for storing database files.</param>
-        /// <param name="configuration">Configuration for the environment.</param>
-        public LightningEnvironment(string path, EnvironmentConfiguration configuration = null)
-        {
-            if (string.IsNullOrWhiteSpace(path))
-                throw new ArgumentException("Invalid directory name");
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("Invalid directory name");
             
-            var config = configuration ?? _config;
+        var config = configuration ?? _config;
 #if NETCOREAPP3_1_OR_GREATER
-            if (config.AutoResizeWindows)
-            {
-                LoadWindowsAutoResizeLibrary();
-            }
+        if (config.AutoResizeWindows)
+        {
+            LoadWindowsAutoResizeLibrary();
+        }
 #endif
 
-            mdb_env_create(out _handle).ThrowOnError();
-            config.Configure(this);
-            _config = config;
+        mdb_env_create(out _handle).ThrowOnError();
+        config.Configure(this);
+        _config = config;
 
-            Path = path;
+        Path = path;
 
-        }
+    }
 
-        public nint Handle()
+    public nint Handle()
+    {
+        return _handle;
+    }
+
+    /// <summary>
+    /// Whether the environment is opened.
+    /// </summary>
+    public bool IsOpened { get; private set; }
+
+    /// <summary>
+    /// Current lmdb version.
+    /// </summary>
+    public LightningVersionInfo Version => LightningVersionInfo.Get();
+
+
+    /// <summary>
+    /// Gets or Sets the size of the memory map to use for this environment.
+    /// The size of the memory map is also the maximum size of the database. 
+    /// The size should be a multiple of the OS page size. 
+    /// The default is 10485760 bytes. 
+    /// </summary>
+    /// <remarks>
+    /// The value should be chosen as large as possible, to accommodate future growth of the database. 
+    /// This function may only be called before the environment is opened.
+    /// The size may be changed by closing and reopening the environment.  
+    /// Any attempt to set a size smaller than the space already consumed by the environment will be silently changed to the current size of the used space. 
+    /// </remarks>
+    public unsafe long MapSize
+    {
+        get => _config.MapSize;
+        set
         {
-            return _handle;
-        }
-
-        /// <summary>
-        /// Whether the environment is opened.
-        /// </summary>
-        public bool IsOpened { get; private set; }
-
-        /// <summary>
-        /// Current lmdb version.
-        /// </summary>
-        public LightningVersionInfo Version => LightningVersionInfo.Get();
-
-
-        /// <summary>
-        /// Gets or Sets the size of the memory map to use for this environment.
-        /// The size of the memory map is also the maximum size of the database. 
-        /// The size should be a multiple of the OS page size. 
-        /// The default is 10485760 bytes. 
-        /// </summary>
-        /// <remarks>
-        /// The value should be chosen as large as possible, to accommodate future growth of the database. 
-        /// This function may only be called before the environment is opened.
-        /// The size may be changed by closing and reopening the environment.  
-        /// Any attempt to set a size smaller than the space already consumed by the environment will be silently changed to the current size of the used space. 
-        /// </remarks>
-        public long MapSize
-        {
-            get { return _config.MapSize; }
-            set
-            {
-                if (value == _config.MapSize) 
-                    return;
-
-                if (_config.AutoReduceMapSizeIn32BitProcess && IntPtr.Size == 4)
-                    _config.MapSize = int.MaxValue;
-                else
-                    _config.MapSize = value;
-
-                mdb_env_set_mapsize(_handle, _config.MapSize).ThrowOnError();
-            }
-        }
-
-        /// <summary>
-        /// Get the maximum number of threads for the environment.
-        /// </summary>
-        public int MaxReaders
-        {
-            get
-            {
-                mdb_env_get_maxreaders(_handle, out var readers).ThrowOnError();
-                return (int) readers;
-            }
-            set
-            {
-                if (IsOpened)
-                    throw new InvalidOperationException("Can't change MaxReaders of opened environment");
-
-                mdb_env_set_maxreaders(_handle, (uint)value).ThrowOnError();
-
-                _config.MaxReaders = value;
-            }
-        }
-
-        /// <summary>
-        /// Set the maximum number of named databases for the environment.
-        /// This function is only needed if multiple databases will be used in the environment. 
-        /// Simpler applications that use the environment as a single unnamed database can ignore this option. 
-        /// This function may only be called before the environment is opened.
-        /// </summary>
-        public int MaxDatabases
-        {
-            get { return _config.MaxDatabases; }
-            set
-            {
-                if (IsOpened)
-                    throw new InvalidOperationException("Can't change MaxDatabases of opened environment");
-
-                if (value == _config.MaxDatabases) 
-                    return;
-
-                mdb_env_set_maxdbs(_handle, (uint)value).ThrowOnError();
-
-                _config.MaxDatabases = value;
-            }
-        }
-
-        /// <summary>
-        /// Get statistics about the LMDB environment. 
-        /// </summary>
-        public Stats EnvironmentStats
-        {
-            get
-            {
-                mdb_env_stat(Handle(), out var nativeStat);
-                return new Stats
-                {
-                    BranchPages = nativeStat.ms_branch_pages,
-                    BTreeDepth = nativeStat.ms_depth,
-                    Entries = nativeStat.ms_entries,
-                    LeafPages = nativeStat.ms_leaf_pages,
-                    OverflowPages = nativeStat.ms_overflow_pages,
-                    PageSize = nativeStat.ms_psize
-                };
-            }
-        }
-
-        /// <summary>
-        /// Gets information about the LMDB environment. 
-        /// </summary>
-        public EnvironmentInfo Info
-        {
-            get
-            {
-                mdb_env_info(Handle(), out var nativeInfo);
-                return new EnvironmentInfo
-                {
-                    MapSize = nativeInfo.me_mapsize,
-                    LastPageNumber = nativeInfo.me_last_pgno,
-                    LastTransactionId = nativeInfo.me_last_txnid,
-                };
-            }
-        }
-
-        /// <summary>
-        /// Directory path to store database files.
-        /// </summary>
-        public string Path { get; }
-
-        /// <summary>
-        /// Open the environment.
-        /// </summary>
-        public void Open(EnvironmentOpenFlags openFlags = EnvironmentOpenFlags.None, UnixAccessMode accessMode = UnixAccessMode.Default)
-        {
-            if(IsOpened)
-                throw new InvalidOperationException("Environment is already opened.");
-
-            if (!openFlags.HasFlag(EnvironmentOpenFlags.NoSubDir) && !Directory.Exists(Path))
-                Directory.CreateDirectory(Path);
-
-            try
-            {
-                mdb_env_open(_handle, Path, openFlags, accessMode).ThrowOnError();
-            }
-            catch(Exception ex)
-            {
-                throw new LightningException($"Failed to open environment at path {Path}", ex);
-            }
-
-            IsOpened = true;
-        }
-
-        /// <summary>
-        /// Create a transaction for use with the environment.
-        /// The transaction handle may be discarded using Abort() or Commit().
-        /// Note:
-        /// Transactions may not span threads; a transaction must only be used by a single thread. Also, a thread may only have a single transaction.
-        /// Cursors may not span transactions; each cursor must be opened and closed within a single transaction.
-        /// </summary>
-        /// <param name="parent">
-        /// If this parameter is non-NULL, the new transaction will be a nested transaction, with the transaction indicated by parent as its parent. 
-        /// Transactions may be nested to any level. 
-        /// A parent transaction may not issue any other operations besides BeginTransaction, Abort, or Commit while it has active child transactions.
-        /// </param>
-        /// <param name="beginFlags">
-        /// Special options for this transaction. 
-        /// </param>
-        /// <returns>
-        /// New LightningTransaction
-        /// </returns>
-        public LightningTransaction BeginTransaction(LightningTransaction parent = null, TransactionBeginFlags beginFlags = LightningTransaction.DefaultTransactionBeginFlags)
-        {
-            if (!IsOpened)
-                throw new InvalidOperationException("Environment must be opened before starting a transaction");
-
-            return new LightningTransaction(this, parent, beginFlags);
-        }
-
-        /// <summary>
-        /// Create a transaction for use with the environment.
-        /// The transaction handle may be discarded usingAbort() or Commit().
-        /// Note:
-        /// Transactions may not span threads; a transaction must only be used by a single thread. Also, a thread may only have a single transaction.
-        /// Cursors may not span transactions; each cursor must be opened and closed within a single transaction.
-        /// </summary>
-        /// <param name="beginFlags">
-        /// Special options for this transaction. 
-        /// </param>
-        /// <returns>
-        /// New LightningTransaction
-        /// </returns>
-        public LightningTransaction BeginTransaction(TransactionBeginFlags beginFlags)
-        {
-            return BeginTransaction(null, beginFlags);
-        }
-
-        /// <summary>
-        /// Copy an MDB environment to the specified path.
-        /// This function may be used to make a backup of an existing environment.
-        /// </summary>
-        /// <param name="path">The directory in which the copy will reside. This directory must already exist and be writable but must otherwise be empty.</param>
-        /// <param name="compact">Omit empty pages when copying.</param>
-        public void CopyTo(string path, bool compact = false)
-        {
-            EnsureOpened();
-
-            var flags = compact 
-                ? EnvironmentCopyFlags.Compact 
-                : EnvironmentCopyFlags.None;
-            
-            mdb_env_copy2(_handle, path, flags);
-        }
-
-        //TODO: tests
-        /// <summary>
-        /// Flush the data buffers to disk. 
-        /// Data is always written to disk when LightningTransaction.Commit is called, but the operating system may keep it buffered. 
-        /// MDB always flushes the OS buffers upon commit as well, unless the environment was opened with EnvironmentOpenFlags.NoSync or in part EnvironmentOpenFlags.NoMetaSync.
-        /// </summary>
-        /// <param name="force">If true, force a synchronous flush. Otherwise if the environment has the EnvironmentOpenFlags.NoSync flag set the flushes will be omitted, and with MDB_MAPASYNC they will be asynchronous.</param>
-        public MDBResultCode Flush(bool force)
-        {
-            return mdb_env_sync(_handle, force);
-        }
-
-        private void EnsureOpened()
-        {
-            if (!IsOpened)
-                throw new InvalidOperationException("Environment should be opened");
-        }
-
-        /// <summary>
-        /// Disposes the environment and deallocates all resources associated with it.
-        /// </summary>
-        /// <param name="disposing">True if called from Dispose.</param>
-        private void Dispose(bool disposing)
-        {
-            if (_handle == IntPtr.Zero)
+            if (value == _config.MapSize) 
                 return;
 
-            if(!disposing)
-                throw new InvalidOperationException("The LightningEnvironment was not disposed and cannot be reliably dealt with from the finalizer");
+            if (_config.AutoReduceMapSizeIn32BitProcess && sizeof(nint) == 4)
+                _config.MapSize = int.MaxValue;
+            else
+                _config.MapSize = value;
 
-            var copy = Disposing;
-            copy?.Invoke();
+            mdb_env_set_mapsize(_handle, _config.MapSize).ThrowOnError();
+        }
+    }
 
+    /// <summary>
+    /// Get the maximum number of threads for the environment.
+    /// </summary>
+    public int MaxReaders
+    {
+        get
+        {
+            mdb_env_get_maxreaders(_handle, out var readers).ThrowOnError();
+            return (int) readers;
+        }
+        set
+        {
             if (IsOpened)
+                throw new InvalidOperationException("Can't change MaxReaders of opened environment");
+
+            mdb_env_set_maxreaders(_handle, (uint)value).ThrowOnError();
+
+            _config.MaxReaders = value;
+        }
+    }
+
+    /// <summary>
+    /// Set the maximum number of named databases for the environment.
+    /// This function is only needed if multiple databases will be used in the environment. 
+    /// Simpler applications that use the environment as a single unnamed database can ignore this option. 
+    /// This function may only be called before the environment is opened.
+    /// </summary>
+    public int MaxDatabases
+    {
+        get => _config.MaxDatabases;
+        set
+        {
+            if (IsOpened)
+                throw new InvalidOperationException("Can't change MaxDatabases of opened environment");
+
+            if (value == _config.MaxDatabases) 
+                return;
+
+            mdb_env_set_maxdbs(_handle, (uint)value).ThrowOnError();
+
+            _config.MaxDatabases = value;
+        }
+    }
+
+    /// <summary>
+    /// Get statistics about the LMDB environment. 
+    /// </summary>
+    public Stats EnvironmentStats
+    {
+        get
+        {
+            mdb_env_stat(Handle(), out var nativeStat);
+            return new Stats
             {
-                mdb_env_close(_handle);
-                IsOpened = false;
-            }
-
-            _handle = IntPtr.Zero;
-            GC.SuppressFinalize(this);
+                BranchPages = nativeStat.ms_branch_pages,
+                BTreeDepth = nativeStat.ms_depth,
+                Entries = nativeStat.ms_entries,
+                LeafPages = nativeStat.ms_leaf_pages,
+                OverflowPages = nativeStat.ms_overflow_pages,
+                PageSize = nativeStat.ms_psize
+            };
         }
+    }
 
-        /// <summary>
-        /// Dispose the environment and release the memory map.
-        /// Only a single thread may call this function. All transactions, databases, and cursors must already be closed before calling this function. 
-        /// Attempts to use any such handles after calling this function will cause a SIGSEGV. 
-        /// The environment handle will be freed and must not be used again after this call.
-        /// </summary>
-        public void Dispose()
+    /// <summary>
+    /// Gets information about the LMDB environment. 
+    /// </summary>
+    public EnvironmentInfo Info
+    {
+        get
         {
-            Dispose(true);
+            mdb_env_info(Handle(), out var nativeInfo);
+            return new EnvironmentInfo
+            {
+                MapSize = nativeInfo.me_mapsize,
+                LastPageNumber = nativeInfo.me_last_pgno,
+                LastTransactionId = nativeInfo.me_last_txnid
+            };
+        }
+    }
+
+    /// <summary>
+    /// Directory path to store database files.
+    /// </summary>
+    public string Path { get; }
+
+    /// <summary>
+    /// Open the environment.
+    /// </summary>
+    public void Open(EnvironmentOpenFlags openFlags = EnvironmentOpenFlags.None, UnixAccessMode accessMode = UnixAccessMode.Default)
+    {
+        if(IsOpened)
+            throw new InvalidOperationException("Environment is already opened.");
+
+        if (!openFlags.HasFlag(EnvironmentOpenFlags.NoSubDir) && !Directory.Exists(Path))
+            Directory.CreateDirectory(Path);
+
+        try
+        {
+            mdb_env_open(_handle, Path, openFlags, accessMode).ThrowOnError();
+        }
+        catch(Exception ex)
+        {
+            throw new LightningException($"Failed to open environment at path {Path}", ex);
         }
 
-        ~LightningEnvironment()
+        IsOpened = true;
+    }
+
+    /// <summary>
+    /// Create a transaction for use with the environment.
+    /// The transaction handle may be discarded using Abort() or Commit().
+    /// Note:
+    /// Transactions may not span threads; a transaction must only be used by a single thread. Also, a thread may only have a single transaction.
+    /// Cursors may not span transactions; each cursor must be opened and closed within a single transaction.
+    /// </summary>
+    /// <param name="parent">
+    /// If this parameter is non-NULL, the new transaction will be a nested transaction, with the transaction indicated by parent as its parent. 
+    /// Transactions may be nested to any level. 
+    /// A parent transaction may not issue any other operations besides BeginTransaction, Abort, or Commit while it has active child transactions.
+    /// </param>
+    /// <param name="beginFlags">
+    /// Special options for this transaction. 
+    /// </param>
+    /// <returns>
+    /// New LightningTransaction
+    /// </returns>
+    public LightningTransaction BeginTransaction(LightningTransaction parent = null, TransactionBeginFlags beginFlags = LightningTransaction.DefaultTransactionBeginFlags)
+    {
+        if (!IsOpened)
+            throw new InvalidOperationException("Environment must be opened before starting a transaction");
+
+        return new LightningTransaction(this, parent, beginFlags);
+    }
+
+    /// <summary>
+    /// Create a transaction for use with the environment.
+    /// The transaction handle may be discarded usingAbort() or Commit().
+    /// Note:
+    /// Transactions may not span threads; a transaction must only be used by a single thread. Also, a thread may only have a single transaction.
+    /// Cursors may not span transactions; each cursor must be opened and closed within a single transaction.
+    /// </summary>
+    /// <param name="beginFlags">
+    /// Special options for this transaction. 
+    /// </param>
+    /// <returns>
+    /// New LightningTransaction
+    /// </returns>
+    public LightningTransaction BeginTransaction(TransactionBeginFlags beginFlags)
+    {
+        return BeginTransaction(null, beginFlags);
+    }
+
+    /// <summary>
+    /// Copy an MDB environment to the specified path.
+    /// This function may be used to make a backup of an existing environment.
+    /// </summary>
+    /// <param name="path">The directory in which the copy will reside. This directory must already exist and be writable but must otherwise be empty.</param>
+    /// <param name="compact">Omit empty pages when copying.</param>
+    public void CopyTo(string path, bool compact = false)
+    {
+        EnsureOpened();
+
+        var flags = compact 
+            ? EnvironmentCopyFlags.Compact 
+            : EnvironmentCopyFlags.None;
+            
+        mdb_env_copy2(_handle, path, flags);
+    }
+
+    /// <summary>
+    /// Flush the data buffers to disk. 
+    /// Data is always written to disk when LightningTransaction.Commit is called, but the operating system may keep it buffered. 
+    /// MDB always flushes the OS buffers upon commit as well, unless the environment was opened with EnvironmentOpenFlags.NoSync or in part EnvironmentOpenFlags.NoMetaSync.
+    /// </summary>
+    /// <param name="force">If true, force a synchronous flush. Otherwise if the environment has the EnvironmentOpenFlags.NoSync flag set the flushes will be omitted, and with MDB_MAPASYNC they will be asynchronous.</param>
+    public MDBResultCode Flush(bool force)
+    {
+        return mdb_env_sync(_handle, force);
+    }
+
+    private void EnsureOpened()
+    {
+        if (!IsOpened)
+            throw new InvalidOperationException("Environment should be opened");
+    }
+
+    /// <summary>
+    /// Disposes the environment and deallocates all resources associated with it.
+    /// </summary>
+    /// <param name="disposing">True if called from Dispose.</param>
+    private void Dispose(bool disposing)
+    {
+        if (_handle == 0)
+            return;
+
+        if(!disposing)
+            throw new InvalidOperationException("The LightningEnvironment was not disposed and cannot be reliably dealt with from the finalizer");
+
+        var copy = Disposing;
+        copy?.Invoke();
+
+        if (IsOpened)
         {
-            Dispose(false);
+            mdb_env_close(_handle);
+            IsOpened = false;
         }
+
+        _handle = 0;
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Dispose the environment and release the memory map.
+    /// Only a single thread may call this function. All transactions, databases, and cursors must already be closed before calling this function. 
+    /// Attempts to use any such handles after calling this function will cause a SIGSEGV. 
+    /// The environment handle will be freed and must not be used again after this call.
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+    }
+
+    ~LightningEnvironment()
+    {
+        Dispose(false);
     }
 }

--- a/src/LightningDB/LightningEnvironment.cs
+++ b/src/LightningDB/LightningEnvironment.cs
@@ -11,7 +11,7 @@ namespace LightningDB
     {
         private readonly EnvironmentConfiguration _config = new EnvironmentConfiguration();
 
-        private IntPtr _handle;
+        private nint _handle;
 
         public event Action Disposing;
 
@@ -41,7 +41,7 @@ namespace LightningDB
 
         }
 
-        public IntPtr Handle()
+        public nint Handle()
         {
             return _handle;
         }
@@ -140,11 +140,11 @@ namespace LightningDB
                 mdb_env_stat(Handle(), out var nativeStat);
                 return new Stats
                 {
-                    BranchPages = nativeStat.ms_branch_pages.ToInt64(),
+                    BranchPages = nativeStat.ms_branch_pages,
                     BTreeDepth = nativeStat.ms_depth,
-                    Entries = nativeStat.ms_entries.ToInt64(),
-                    LeafPages = nativeStat.ms_leaf_pages.ToInt64(),
-                    OverflowPages = nativeStat.ms_overflow_pages.ToInt64(),
+                    Entries = nativeStat.ms_entries,
+                    LeafPages = nativeStat.ms_leaf_pages,
+                    OverflowPages = nativeStat.ms_overflow_pages,
                     PageSize = nativeStat.ms_psize
                 };
             }
@@ -160,9 +160,9 @@ namespace LightningDB
                 mdb_env_info(Handle(), out var nativeInfo);
                 return new EnvironmentInfo
                 {
-                    MapSize = nativeInfo.me_mapsize.ToInt64(),
-                    LastPageNumber = nativeInfo.me_last_pgno.ToInt64(),
-                    LastTransactionId = nativeInfo.me_last_txnid.ToInt64(),
+                    MapSize = nativeInfo.me_mapsize,
+                    LastPageNumber = nativeInfo.me_last_pgno,
+                    LastTransactionId = nativeInfo.me_last_txnid,
                 };
             }
         }

--- a/src/LightningDB/LightningException.cs
+++ b/src/LightningDB/LightningException.cs
@@ -1,29 +1,28 @@
 ﻿using System;
 
-namespace LightningDB
+namespace LightningDB;
+
+/// <summary>
+/// An exception caused by lmdb operations.
+/// </summary>
+public class LightningException : Exception
 {
-    /// <summary>
-    /// An exception caused by lmdb operations.
-    /// </summary>
-    public class LightningException : Exception
+    internal LightningException(string message, int statusCode) : base (message)
     {
-        internal LightningException(string message, int statusCode) : base (message)
-        {
-            StatusCode = statusCode;
-        }
+        StatusCode = statusCode;
+    }
 
-        internal LightningException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
+    internal LightningException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
 
-        /// <summary>
-        /// The status code LMDB returned from an operation.
-        /// </summary>
-        public int StatusCode { get; }
+    /// <summary>
+    /// The status code LMDB returned from an operation.
+    /// </summary>
+    public int StatusCode { get; }
 
-        public override string ToString()
-        {
-            return $"LightningDB {StatusCode}: {Message}";
-        }
+    public override string ToString()
+    {
+        return $"LightningDB {StatusCode}: {Message}";
     }
 }

--- a/src/LightningDB/LightningExtensions.cs
+++ b/src/LightningDB/LightningExtensions.cs
@@ -4,159 +4,157 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using LightningDB.Native;
 
-namespace LightningDB
+namespace LightningDB;
+
+public static class LightningExtensions
 {
-    public static class LightningExtensions
+    /// <summary>
+    /// Throws a <see cref="LightningException"/> on anything other than NotFound, or Success
+    /// </summary>
+    /// <param name="resultCode">The result code to evaluate for errors</param>
+    /// <returns><see cref="MDBResultCode"/></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static MDBResultCode ThrowOnReadError(this MDBResultCode resultCode)
     {
-        /// <summary>
-        /// Throws a <see cref="LightningException"/> on anything other than NotFound, or Success
-        /// </summary>
-        /// <param name="resultCode">The result code to evaluate for errors</param>
-        /// <returns><see cref="MDBResultCode"/></returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static MDBResultCode ThrowOnReadError(this MDBResultCode resultCode)
-        {
-            if (resultCode == MDBResultCode.NotFound)
-                return resultCode;
-            return resultCode.ThrowOnError();
-        }
+        return resultCode == MDBResultCode.NotFound 
+            ? resultCode : resultCode.ThrowOnError();
+    }
 
-        /// <summary>
-        /// Throws a <see cref="LightningException"/> on anything other than Success
-        /// </summary>
-        /// <param name="resultCode">The result code to evaluate for errors</param>
-        /// <returns><see cref="MDBResultCode"/></returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static MDBResultCode ThrowOnError(this MDBResultCode resultCode)
-        {
-            if (resultCode == MDBResultCode.Success)
-                return resultCode;
-            var statusCode = (int) resultCode;
-            var message = mdb_strerror(statusCode);
-            throw new LightningException(message, statusCode); 
-        }
+    /// <summary>
+    /// Throws a <see cref="LightningException"/> on anything other than Success
+    /// </summary>
+    /// <param name="resultCode">The result code to evaluate for errors</param>
+    /// <returns><see cref="MDBResultCode"/></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static MDBResultCode ThrowOnError(this MDBResultCode resultCode)
+    {
+        if (resultCode == MDBResultCode.Success)
+            return resultCode;
+        var statusCode = (int) resultCode;
+        var message = mdb_strerror(statusCode);
+        throw new LightningException(message, statusCode); 
+    }
 
-        /// <summary>
-        /// Throws a <see cref="LightningException"/> on anything other than NotFound, or Success 
-        /// </summary>
-        /// <param name="result">A <see cref="ValueTuple"/> representing the get result operation</param>
-        /// <returns>The provided <see cref="ValueTuple"/> if no error occurs</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static (MDBResultCode resultCode, MDBValue key, MDBValue value) ThrowOnReadError(
-            this ValueTuple<MDBResultCode, MDBValue, MDBValue> result)
-        {
-            result.Item1.ThrowOnReadError();
-            return result;
-        }
+    /// <summary>
+    /// Throws a <see cref="LightningException"/> on anything other than NotFound, or Success 
+    /// </summary>
+    /// <param name="result">A <see cref="ValueTuple"/> representing the get result operation</param>
+    /// <returns>The provided <see cref="ValueTuple"/> if no error occurs</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static (MDBResultCode resultCode, MDBValue key, MDBValue value) ThrowOnReadError(
+        this ValueTuple<MDBResultCode, MDBValue, MDBValue> result)
+    {
+        result.Item1.ThrowOnReadError();
+        return result;
+    }
         
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static string mdb_strerror(int err)
-        {
-            var ptr = Lmdb.mdb_strerror(err);
-            return Marshal.PtrToStringAnsi(ptr);
-        }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static string mdb_strerror(int err)
+    {
+        var ptr = Lmdb.mdb_strerror(err);
+        return Marshal.PtrToStringAnsi(ptr);
+    }
 
-        /// <summary>
-        /// Enumerates the key/value pairs of the <see cref="LightningCursor"/> starting at the current position.
-        /// </summary>
-        /// <param name="cursor"><see cref="LightningCursor"/></param>
-        /// <returns><see cref="ValueTuple"/> key/value pairs of <see cref="MDBValue"/></returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static IEnumerable<ValueTuple<MDBValue, MDBValue>> AsEnumerable(this LightningCursor cursor)
+    /// <summary>
+    /// Enumerates the key/value pairs of the <see cref="LightningCursor"/> starting at the current position.
+    /// </summary>
+    /// <param name="cursor"><see cref="LightningCursor"/></param>
+    /// <returns><see cref="ValueTuple"/> key/value pairs of <see cref="MDBValue"/></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static IEnumerable<ValueTuple<MDBValue, MDBValue>> AsEnumerable(this LightningCursor cursor)
+    {
+        while(cursor.Next() == MDBResultCode.Success)
         {
-            while(cursor.Next() == MDBResultCode.Success)
-            {
-                var (resultCode, key, value) = cursor.GetCurrent();
-                resultCode.ThrowOnError();
-                yield return (key, value);
-            }
+            var (resultCode, key, value) = cursor.GetCurrent();
+            resultCode.ThrowOnError();
+            yield return (key, value);
         }
+    }
 
-        /// <summary>
-        /// Tries to get a value by its key.
-        /// </summary>
-        /// <param name="tx">The transaction.</param>
-        /// <param name="db">The database to query.</param>
-        /// <param name="key">A span containing the key to look up.</param>
-        /// <param name="value">A byte array containing the value found in the database, if it exists.</param>
-        /// <returns>True if key exists, false if not.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryGet(this LightningTransaction tx, LightningDatabase db, byte[] key, out byte[] value)
-        {
-            return TryGet(tx, db, key.AsSpan(), out value);
-        }
+    /// <summary>
+    /// Tries to get a value by its key.
+    /// </summary>
+    /// <param name="tx">The transaction.</param>
+    /// <param name="db">The database to query.</param>
+    /// <param name="key">A span containing the key to look up.</param>
+    /// <param name="value">A byte array containing the value found in the database, if it exists.</param>
+    /// <returns>True if key exists, false if not.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool TryGet(this LightningTransaction tx, LightningDatabase db, byte[] key, out byte[] value)
+    {
+        return TryGet(tx, db, key.AsSpan(), out value);
+    }
         
-        /// <summary>
-        /// Tries to get a value by its key.
-        /// </summary>
-        /// <param name="tx">The transaction.</param>
-        /// <param name="db">The database to query.</param>
-        /// <param name="key">A span containing the key to look up.</param>
-        /// <param name="value">A byte array containing the value found in the database, if it exists.</param>
-        /// <returns>True if key exists, false if not.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryGet(this LightningTransaction tx, LightningDatabase db, ReadOnlySpan<byte> key, out byte[] value)
+    /// <summary>
+    /// Tries to get a value by its key.
+    /// </summary>
+    /// <param name="tx">The transaction.</param>
+    /// <param name="db">The database to query.</param>
+    /// <param name="key">A span containing the key to look up.</param>
+    /// <param name="value">A byte array containing the value found in the database, if it exists.</param>
+    /// <returns>True if key exists, false if not.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool TryGet(this LightningTransaction tx, LightningDatabase db, ReadOnlySpan<byte> key, out byte[] value)
+    {
+        var (resultCode, _, mdbValue) = tx.Get(db, key);
+        if (resultCode == MDBResultCode.Success)
         {
-            var (resultCode, _, mdbValue) = tx.Get(db, key);
-            if (resultCode == MDBResultCode.Success)
-            {
-                value = mdbValue.CopyToNewArray();
-                return true;
-            }
-            value = default;
+            value = mdbValue.CopyToNewArray();
+            return true;
+        }
+        value = default;
+        return false;
+    }
+        
+    /// <summary>
+    /// Tries to get a value by its key.
+    /// </summary>
+    /// <param name="tx">The transaction.</param>
+    /// <param name="db">The database to query.</param>
+    /// <param name="key">A span containing the key to look up.</param>
+    /// <param name="destinationValueBuffer">
+    /// A buffer to receive the value data retrieved from the database
+    /// </param>
+    /// <returns>True if key exists, false if not.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool TryGet(this LightningTransaction tx, LightningDatabase db, ReadOnlySpan<byte> key, byte[] destinationValueBuffer)
+    {
+        var (resultCode, _, mdbValue) = tx.Get(db, key);
+        if (resultCode != MDBResultCode.Success) 
             return false;
-        }
-        
-        /// <summary>
-        /// Tries to get a value by its key.
-        /// </summary>
-        /// <param name="tx">The transaction.</param>
-        /// <param name="db">The database to query.</param>
-        /// <param name="key">A span containing the key to look up.</param>
-        /// <param name="destinationValueBuffer">
-        /// A buffer to receive the value data retrieved from the database
-        /// </param>
-        /// <returns>True if key exists, false if not.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryGet(this LightningTransaction tx, LightningDatabase db, ReadOnlySpan<byte> key, byte[] destinationValueBuffer)
-        {
-            var (resultCode, _, mdbValue) = tx.Get(db, key);
-            if (resultCode != MDBResultCode.Success) 
-                return false;
             
-            var valueSpan = mdbValue.AsSpan();
-            if (valueSpan.TryCopyTo(destinationValueBuffer))
-            {
-                return true;
-            }
-            throw new LightningException("Incorrect buffer size given in destinationValueBuffer", (int)MDBResultCode.BadValSize);
-        }
-        
-        /// <summary>
-        /// Check whether data exists in database.
-        /// </summary>
-        /// <param name="tx">The transaction.</param>
-        /// <param name="db">The database to query.</param>
-        /// <param name="key">A span containing the key to look up.</param>
-        /// <returns>True if key exists, false if not.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ContainsKey(this LightningTransaction tx, LightningDatabase db, ReadOnlySpan<byte> key)
+        var valueSpan = mdbValue.AsSpan();
+        if (valueSpan.TryCopyTo(destinationValueBuffer))
         {
-            var (resultCode, _, _) = tx.Get(db, key);
-            return resultCode == MDBResultCode.Success;
+            return true;
         }
+        throw new LightningException("Incorrect buffer size given in destinationValueBuffer", (int)MDBResultCode.BadValSize);
+    }
         
-        /// <summary>
-        /// Check whether data exists in database.
-        /// </summary>
-        /// <param name="tx">The transaction.</param>
-        /// <param name="db">The database to query.</param>
-        /// <param name="key">A span containing the key to look up.</param>
-        /// <returns>True if key exists, false if not.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ContainsKey(this LightningTransaction tx, LightningDatabase db, byte[] key)
-        {
-            return ContainsKey(tx, db, key.AsSpan());
-        }
+    /// <summary>
+    /// Check whether data exists in database.
+    /// </summary>
+    /// <param name="tx">The transaction.</param>
+    /// <param name="db">The database to query.</param>
+    /// <param name="key">A span containing the key to look up.</param>
+    /// <returns>True if key exists, false if not.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool ContainsKey(this LightningTransaction tx, LightningDatabase db, ReadOnlySpan<byte> key)
+    {
+        var (resultCode, _, _) = tx.Get(db, key);
+        return resultCode == MDBResultCode.Success;
+    }
+        
+    /// <summary>
+    /// Check whether data exists in database.
+    /// </summary>
+    /// <param name="tx">The transaction.</param>
+    /// <param name="db">The database to query.</param>
+    /// <param name="key">A span containing the key to look up.</param>
+    /// <returns>True if key exists, false if not.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool ContainsKey(this LightningTransaction tx, LightningDatabase db, byte[] key)
+    {
+        return ContainsKey(tx, db, key.AsSpan());
     }
 }

--- a/src/LightningDB/LightningTransaction.cs
+++ b/src/LightningDB/LightningTransaction.cs
@@ -2,398 +2,392 @@
 
 using static LightningDB.Native.Lmdb;
 
-namespace LightningDB
+namespace LightningDB;
+
+/// <summary>
+/// Represents a transaction.
+/// </summary>
+public sealed class LightningTransaction : IDisposable
 {
     /// <summary>
-    /// Represents a transaction.
+    /// Default options used to begin new transactions.
     /// </summary>
-    public sealed class LightningTransaction : IDisposable
+    public const TransactionBeginFlags DefaultTransactionBeginFlags = TransactionBeginFlags.None;
+
+    private nint _handle;
+    private readonly nint _originalHandle;
+
+    /// <summary>
+    /// Created new instance of LightningTransaction
+    /// </summary>
+    /// <param name="environment">Environment.</param>
+    /// <param name="parent">Parent transaction or null.</param>
+    /// <param name="flags">Transaction open options.</param>
+    internal LightningTransaction(LightningEnvironment environment, LightningTransaction parent, TransactionBeginFlags flags)
     {
-        /// <summary>
-        /// Default options used to begin new transactions.
-        /// </summary>
-        public const TransactionBeginFlags DefaultTransactionBeginFlags = TransactionBeginFlags.None;
-
-        private nint _handle;
-        private readonly nint _originalHandle;
-
-        /// <summary>
-        /// Created new instance of LightningTransaction
-        /// </summary>
-        /// <param name="environment">Environment.</param>
-        /// <param name="parent">Parent transaction or null.</param>
-        /// <param name="flags">Transaction open options.</param>
-        internal LightningTransaction(LightningEnvironment environment, LightningTransaction parent, TransactionBeginFlags flags)
+        Environment = environment ?? throw new ArgumentNullException(nameof(environment));
+        ParentTransaction = parent;
+        IsReadOnly = flags == TransactionBeginFlags.ReadOnly;
+        State = LightningTransactionState.Active;
+        Environment.Disposing += Dispose;
+        if (parent != null)
         {
-            Environment = environment ?? throw new ArgumentNullException(nameof(environment));
-            ParentTransaction = parent;
-            IsReadOnly = flags == TransactionBeginFlags.ReadOnly;
-            State = LightningTransactionState.Active;
-            Environment.Disposing += Dispose;
-            if (parent != null)
-            {
-                parent.Disposing += Dispose;
-                parent.StateChanging += OnParentStateChanging;
-            }
-
-            var parentHandle = parent?.Handle() ?? IntPtr.Zero;
-            mdb_txn_begin(environment.Handle(), parentHandle, flags, out _handle).ThrowOnError();
-            _originalHandle = _handle;
+            parent.Disposing += Dispose;
+            parent.StateChanging += OnParentStateChanging;
         }
 
-        public nint Handle()
+        var parentHandle = parent?.Handle() ?? default(nint);
+        mdb_txn_begin(environment.Handle(), parentHandle, flags, out _handle).ThrowOnError();
+        _originalHandle = _handle;
+    }
+
+    public nint Handle()
+    {
+        return _handle;
+    }
+
+    private void OnParentStateChanging(LightningTransactionState state)
+    {
+        switch (state)
         {
-            return _handle;
+            case LightningTransactionState.Aborted:
+            case LightningTransactionState.Committed:
+                Abort();
+                break;
         }
+    }
 
-        private void OnParentStateChanging(LightningTransactionState state)
-        {
-            switch (state)
-            {
-                case LightningTransactionState.Aborted:
-                case LightningTransactionState.Commited:
-                    Abort();
-                    break;
-                default:
-                    break;
-            }
-        }
+    public event Action Disposing;
+    private event Action<LightningTransactionState> StateChanging;
 
-        public event Action Disposing;
-        private event Action<LightningTransactionState> StateChanging;
+    /// <summary>
+    /// Current transaction state.
+    /// </summary>
+    public LightningTransactionState State { get; private set; }
 
-        /// <summary>
-        /// Current transaction state.
-        /// </summary>
-        public LightningTransactionState State { get; private set; }
+    /// <summary>
+    /// Begin a child transaction.
+    /// </summary>
+    /// <param name="beginFlags">Options for a new transaction.</param>
+    /// <returns>New child transaction.</returns>
+    public LightningTransaction BeginTransaction(TransactionBeginFlags beginFlags = DefaultTransactionBeginFlags)
+    {
+        return new LightningTransaction(Environment, this, beginFlags);
+    }
 
-        /// <summary>
-        /// Begin a child transaction.
-        /// </summary>
-        /// <param name="beginFlags">Options for a new transaction.</param>
-        /// <returns>New child transaction.</returns>
-        public LightningTransaction BeginTransaction(TransactionBeginFlags beginFlags = DefaultTransactionBeginFlags)
-        {
-            return new LightningTransaction(Environment, this, beginFlags);
-        }
+    /// <summary>
+    /// Opens a database in context of this transaction.
+    /// </summary>
+    /// <param name="name">Database name (optional). If null then the default name is used.</param>
+    /// <param name="configuration">Database open options.</param>
+    /// <param name="closeOnDispose">Close database handle on dispose</param>
+    /// <returns>Created database wrapper.</returns>
+    public LightningDatabase OpenDatabase(string name = null, DatabaseConfiguration configuration = null, bool closeOnDispose = true)
+    {
+        configuration ??= new DatabaseConfiguration();
+        var db = new LightningDatabase(name, this, configuration, closeOnDispose);
+        return db;
+    }
 
-        /// <summary>
-        /// Opens a database in context of this transaction.
-        /// </summary>
-        /// <param name="name">Database name (optional). If null then the default name is used.</param>
-        /// <param name="configuration">Database open options.</param>
-        /// <param name="closeOnDispose">Close database handle on dispose</param>
-        /// <returns>Created database wrapper.</returns>
-        public LightningDatabase OpenDatabase(string name = null, DatabaseConfiguration configuration = null, bool closeOnDispose = true)
-        {
-            configuration = configuration ?? new DatabaseConfiguration();
-            var db = new LightningDatabase(name, this, configuration, closeOnDispose);
-            return db;
-        }
+    /// <summary>
+    /// Drops the database.
+    /// </summary>
+    public MDBResultCode DropDatabase(LightningDatabase database)
+    {
+        return database.Drop(this);
+    }
 
-        /// <summary>
-        /// Drops the database.
-        /// </summary>
-        public MDBResultCode DropDatabase(LightningDatabase database)
-        {
-            return database.Drop(this);
-        }
+    /// <summary>
+    /// Truncates all data from the database.
+    /// </summary>
+    public MDBResultCode TruncateDatabase(LightningDatabase database)
+    {
+        return database.Truncate(this);
+    }
 
-        /// <summary>
-        /// Truncates all data from the database.
-        /// </summary>
-        public MDBResultCode TruncateDatabase(LightningDatabase database)
-        {
-            return database.Truncate(this);
-        }
+    /// <summary>
+    /// Create a cursor.
+    /// Cursors are associated with a specific transaction and database and may not span threads.
+    /// </summary>
+    /// <param name="db">A database.</param>
+    public LightningCursor CreateCursor(LightningDatabase db)
+    {
+        return new LightningCursor(db, this);
+    }
 
-        /// <summary>
-        /// Create a cursor.
-        /// Cursors are associated with a specific transaction and database and may not span threads.
-        /// </summary>
-        /// <param name="db">A database.</param>
-        public LightningCursor CreateCursor(LightningDatabase db)
-        {
-            return new LightningCursor(db, this);
-        }
-
-        /// <summary>
-        /// Get value from a database.
-        /// </summary>
-        /// <param name="db">The database to query.</param>
-        /// <param name="key">An array containing the key to look up.</param>
-        /// <returns>Requested value's byte array if exists, or null if not.</returns>
-        public (MDBResultCode resultCode, MDBValue key, MDBValue value) Get(LightningDatabase db, byte[] key)
-        {//argument validation delegated to next call
+    /// <summary>
+    /// Get value from a database.
+    /// </summary>
+    /// <param name="db">The database to query.</param>
+    /// <param name="key">An array containing the key to look up.</param>
+    /// <returns>Requested value's byte array if exists, or null if not.</returns>
+    public (MDBResultCode resultCode, MDBValue key, MDBValue value) Get(LightningDatabase db, byte[] key)
+    {//argument validation delegated to next call
             
-            return Get(db, key.AsSpan());
-        }
+        return Get(db, key.AsSpan());
+    }
 
-        /// <summary>
-        /// Get value from a database.
-        /// </summary>
-        /// <param name="db">The database to query.</param>
-        /// <param name="key">A span containing the key to look up.</param>
-        /// <returns>Requested value's byte array if exists, or null if not.</returns>
-        public unsafe (MDBResultCode resultCode, MDBValue key, MDBValue value) Get(LightningDatabase db, ReadOnlySpan<byte> key)
+    /// <summary>
+    /// Get value from a database.
+    /// </summary>
+    /// <param name="db">The database to query.</param>
+    /// <param name="key">A span containing the key to look up.</param>
+    /// <returns>Requested value's byte array if exists, or null if not.</returns>
+    public unsafe (MDBResultCode resultCode, MDBValue key, MDBValue value) Get(LightningDatabase db, ReadOnlySpan<byte> key)
+    {
+        if (db == null)
+            throw new ArgumentNullException(nameof(db));
+
+        fixed(byte* keyBuffer = key)
         {
-            if (db == null)
-                throw new ArgumentNullException(nameof(db));
+            var mdbKey = new MDBValue(key.Length, keyBuffer);
 
-            fixed(byte* keyBuffer = key)
+            return (mdb_get(_handle, db.Handle(), ref mdbKey, out var mdbValue), mdbKey, mdbValue);
+        }
+    }
+
+    /// <summary>
+    /// Put data into a database.
+    /// </summary>
+    /// <param name="db">The database to query.</param>
+    /// <param name="key">A span containing the key to look up.</param>
+    /// <param name="value">A byte array containing the value found in the database, if it exists.</param>
+    /// <param name="options">Operation options (optional).</param>
+    public MDBResultCode Put(LightningDatabase db, byte[] key, byte[] value, PutOptions options = PutOptions.None)
+    {//argument validation delegated to next call
+        return Put(db, key.AsSpan(), value.AsSpan(), options);
+    }
+
+    /// <summary>
+    /// Put data into a database.
+    /// </summary>
+    /// <param name="db">Database.</param>
+    /// <param name="key">Key byte array.</param>
+    /// <param name="value">Value byte array.</param>
+    /// <param name="options">Operation options (optional).</param>
+    public unsafe MDBResultCode Put(LightningDatabase db, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, PutOptions options = PutOptions.None)
+    {
+        if (db == null)
+            throw new ArgumentNullException(nameof(db));
+
+        fixed (byte* keyPtr = key)
+        fixed (byte* valuePtr = value)
+        {
+            var mdbKey = new MDBValue(key.Length, keyPtr);
+            var mdbValue = new MDBValue(value.Length, valuePtr);
+
+            return mdb_put(_handle, db.Handle(), mdbKey, mdbValue, options);
+        }
+    }
+
+    /// <summary>
+    /// Delete items from a database.
+    /// This function removes key/data pairs from the database.
+    /// If the database does not support sorted duplicate data items (MDB_DUPSORT) the data parameter is ignored.
+    /// If the database supports sorted duplicates and the data parameter is NULL, all of the duplicate data items for the key will be deleted.
+    /// Otherwise, if the data parameter is non-NULL only the matching data item will be deleted.
+    /// This function will return MDB_NOTFOUND if the specified key/data pair is not in the database.
+    /// </summary>
+    /// <param name="db">A database handle returned by mdb_dbi_open()</param>
+    /// <param name="key">The key to delete from the database</param>
+    /// <param name="value">The data to delete (optional)</param>
+    public MDBResultCode Delete(LightningDatabase db, byte[] key, byte[] value)
+    {//argument validation delegated to next call
+        return Delete(db, key.AsSpan(), value.AsSpan());
+    }
+
+    /// <summary>
+    /// Delete items from a database.
+    /// This function removes key/data pairs from the database.
+    /// If the database does not support sorted duplicate data items (MDB_DUPSORT) the data parameter is ignored.
+    /// If the database supports sorted duplicates and the data parameter is NULL, all of the duplicate data items for the key will be deleted.
+    /// Otherwise, if the data parameter is non-NULL only the matching data item will be deleted.
+    /// This function will return MDB_NOTFOUND if the specified key/data pair is not in the database.
+    /// </summary>
+    /// <param name="db">A database handle returned by mdb_dbi_open()</param>
+    /// <param name="key">The key to delete from the database</param>
+    /// <param name="value">The data to delete (optional)</param>
+    public unsafe MDBResultCode Delete(LightningDatabase db, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
+    {
+        if (db == null)
+            throw new ArgumentNullException(nameof(db));
+
+        fixed (byte* keyPtr = key)
+        fixed (byte* valuePtr = value)
+        {
+            var mdbKey = new MDBValue(key.Length, keyPtr);
+            if (value == null)
             {
-                var mdbKey = new MDBValue(key.Length, keyBuffer);
-
-                return (mdb_get(_handle, db.Handle(), ref mdbKey, out var mdbValue), mdbKey, mdbValue);
-            }
-        }
-
-        /// <summary>
-        /// Put data into a database.
-        /// </summary>
-        /// <param name="db">The database to query.</param>
-        /// <param name="key">A span containing the key to look up.</param>
-        /// <param name="value">A byte array containing the value found in the database, if it exists.</param>
-        /// <param name="options">Operation options (optional).</param>
-        public MDBResultCode Put(LightningDatabase db, byte[] key, byte[] value, PutOptions options = PutOptions.None)
-        {//argument validation delegated to next call
-            return Put(db, key.AsSpan(), value.AsSpan(), options);
-        }
-
-        /// <summary>
-        /// Put data into a database.
-        /// </summary>
-        /// <param name="db">Database.</param>
-        /// <param name="key">Key byte array.</param>
-        /// <param name="value">Value byte array.</param>
-        /// <param name="options">Operation options (optional).</param>
-        public unsafe MDBResultCode Put(LightningDatabase db, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, PutOptions options = PutOptions.None)
-        {
-            if (db == null)
-                throw new ArgumentNullException(nameof(db));
-
-            fixed (byte* keyPtr = key)
-            fixed (byte* valuePtr = value)
-            {
-                var mdbKey = new MDBValue(key.Length, keyPtr);
-                var mdbValue = new MDBValue(value.Length, valuePtr);
-
-                return mdb_put(_handle, db.Handle(), mdbKey, mdbValue, options);
-            }
-        }
-
-        /// <summary>
-        /// Delete items from a database.
-        /// This function removes key/data pairs from the database.
-        /// If the database does not support sorted duplicate data items (MDB_DUPSORT) the data parameter is ignored.
-        /// If the database supports sorted duplicates and the data parameter is NULL, all of the duplicate data items for the key will be deleted.
-        /// Otherwise, if the data parameter is non-NULL only the matching data item will be deleted.
-        /// This function will return MDB_NOTFOUND if the specified key/data pair is not in the database.
-        /// </summary>
-        /// <param name="db">A database handle returned by mdb_dbi_open()</param>
-        /// <param name="key">The key to delete from the database</param>
-        /// <param name="value">The data to delete (optional)</param>
-        public MDBResultCode Delete(LightningDatabase db, byte[] key, byte[] value)
-        {//argument validation delegated to next call
-            return Delete(db, key.AsSpan(), value.AsSpan());
-        }
-
-        /// <summary>
-        /// Delete items from a database.
-        /// This function removes key/data pairs from the database.
-        /// If the database does not support sorted duplicate data items (MDB_DUPSORT) the data parameter is ignored.
-        /// If the database supports sorted duplicates and the data parameter is NULL, all of the duplicate data items for the key will be deleted.
-        /// Otherwise, if the data parameter is non-NULL only the matching data item will be deleted.
-        /// This function will return MDB_NOTFOUND if the specified key/data pair is not in the database.
-        /// </summary>
-        /// <param name="db">A database handle returned by mdb_dbi_open()</param>
-        /// <param name="key">The key to delete from the database</param>
-        /// <param name="value">The data to delete (optional)</param>
-        public unsafe MDBResultCode Delete(LightningDatabase db, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
-        {
-            if (db == null)
-                throw new ArgumentNullException(nameof(db));
-
-            fixed (byte* keyPtr = key)
-            fixed (byte* valuePtr = value)
-            {
-                var mdbKey = new MDBValue(key.Length, keyPtr);
-                if (value == null)
-                {
-                    return mdb_del(_handle, db.Handle(), mdbKey);
-                }
-                var mdbValue = new MDBValue(value.Length, valuePtr);
-                return mdb_del(_handle, db.Handle(), mdbKey, mdbValue);
-            }
-        }
-
-        /// <summary>
-        /// Delete items from a database.
-        /// This function removes key/data pairs from the database. 
-        /// If the database does not support sorted duplicate data items (MDB_DUPSORT) the data parameter is ignored. 
-        /// If the database supports sorted duplicates and the data parameter is NULL, all of the duplicate data items for the key will be deleted. 
-        /// Otherwise, if the data parameter is non-NULL only the matching data item will be deleted. 
-        /// This function will return MDB_NOTFOUND if the specified key/data pair is not in the database.
-        /// </summary>
-        /// <param name="db">A database handle returned by mdb_dbi_open()</param>
-        /// <param name="key">The key to delete from the database</param>
-        public MDBResultCode Delete(LightningDatabase db, byte[] key)
-        {
-            return Delete(db, key.AsSpan());
-        }
-
-
-        /// <summary>
-        /// Delete items from a database.
-        /// This function removes key/data pairs from the database. 
-        /// If the database does not support sorted duplicate data items (MDB_DUPSORT) the data parameter is ignored. 
-        /// If the database supports sorted duplicates and the data parameter is NULL, all of the duplicate data items for the key will be deleted. 
-        /// Otherwise, if the data parameter is non-NULL only the matching data item will be deleted. 
-        /// This function will return MDB_NOTFOUND if the specified key/data pair is not in the database.
-        /// </summary>
-        /// <param name="db">A database handle returned by mdb_dbi_open()</param>
-        /// <param name="key">The key to delete from the database</param>
-        public unsafe MDBResultCode Delete(LightningDatabase db, ReadOnlySpan<byte> key)
-        {
-            fixed(byte* ptr = key) {
-                var mdbKey = new MDBValue(key.Length, ptr);
                 return mdb_del(_handle, db.Handle(), mdbKey);
             }
+            var mdbValue = new MDBValue(value.Length, valuePtr);
+            return mdb_del(_handle, db.Handle(), mdbKey, mdbValue);
         }
+    }
 
-        /// <summary>
-        /// Reset current transaction.
-        /// </summary>
-        public void Reset()
+    /// <summary>
+    /// Delete items from a database.
+    /// This function removes key/data pairs from the database. 
+    /// If the database does not support sorted duplicate data items (MDB_DUPSORT) the data parameter is ignored. 
+    /// If the database supports sorted duplicates and the data parameter is NULL, all of the duplicate data items for the key will be deleted. 
+    /// Otherwise, if the data parameter is non-NULL only the matching data item will be deleted. 
+    /// This function will return MDB_NOTFOUND if the specified key/data pair is not in the database.
+    /// </summary>
+    /// <param name="db">A database handle returned by mdb_dbi_open()</param>
+    /// <param name="key">The key to delete from the database</param>
+    public MDBResultCode Delete(LightningDatabase db, byte[] key)
+    {
+        return Delete(db, key.AsSpan());
+    }
+
+
+    /// <summary>
+    /// Delete items from a database.
+    /// This function removes key/data pairs from the database. 
+    /// If the database does not support sorted duplicate data items (MDB_DUPSORT) the data parameter is ignored. 
+    /// If the database supports sorted duplicates and the data parameter is NULL, all of the duplicate data items for the key will be deleted. 
+    /// Otherwise, if the data parameter is non-NULL only the matching data item will be deleted. 
+    /// This function will return MDB_NOTFOUND if the specified key/data pair is not in the database.
+    /// </summary>
+    /// <param name="db">A database handle returned by mdb_dbi_open()</param>
+    /// <param name="key">The key to delete from the database</param>
+    public unsafe MDBResultCode Delete(LightningDatabase db, ReadOnlySpan<byte> key)
+    {
+        fixed(byte* ptr = key) {
+            var mdbKey = new MDBValue(key.Length, ptr);
+            return mdb_del(_handle, db.Handle(), mdbKey);
+        }
+    }
+
+    /// <summary>
+    /// Reset current transaction.
+    /// </summary>
+    public void Reset()
+    {
+        if (!IsReadOnly)
+            throw new InvalidOperationException("Can't reset non-readonly transaction");
+
+        mdb_txn_reset(_handle);
+        State = LightningTransactionState.Reset;
+    }
+
+    /// <summary>
+    /// Renew current transaction.
+    /// </summary>
+    public MDBResultCode Renew()
+    {
+        if (!IsReadOnly)
+            throw new InvalidOperationException("Can't renew non-readonly transaction");
+
+        if (State != LightningTransactionState.Reset)
+            throw new InvalidOperationException("Transaction should be reset first");
+
+        var result = mdb_txn_renew(_handle);
+        State = LightningTransactionState.Active;
+        return result;
+    }
+
+    /// <summary>
+    /// Commit all the operations of a transaction into the database.
+    /// All cursors opened within the transaction will be closed by this call. 
+    /// The cursors and transaction handle will be freed and must not be used again after this call.
+    /// </summary>
+    public MDBResultCode Commit()
+    {
+        State = LightningTransactionState.Committed;
+        StateChanging?.Invoke(State);
+        return mdb_txn_commit(_handle);
+    }
+
+    /// <summary>
+    /// Abandon all the operations of the transaction instead of saving them.
+    /// All cursors opened within the transaction will be closed by this call.
+    /// The cursors and transaction handle will be freed and must not be used again after this call.
+    /// </summary>
+    public void Abort()
+    {
+        State = LightningTransactionState.Aborted;
+        StateChanging?.Invoke(State);
+        mdb_txn_abort(_handle);
+    }
+
+    /// <summary>
+    /// The number of items in the database.
+    /// </summary>
+    /// <param name="db">The database we are counting items in.</param>
+    /// <returns>The number of items.</returns>
+    public long GetEntriesCount(LightningDatabase db)
+    {
+        mdb_stat(_handle, db.Handle(), out var stat).ThrowOnError();
+
+        return stat.ms_entries;
+    }
+
+    /// <summary>
+    /// Environment in which the transaction was opened.
+    /// </summary>
+    public LightningEnvironment Environment { get; }
+
+    /// <summary>
+    /// Parent transaction of this transaction.
+    /// </summary>
+    public LightningTransaction ParentTransaction { get; }
+
+    /// <summary>
+    /// Whether this transaction is read-only.
+    /// </summary>
+    public bool IsReadOnly { get; }
+
+    /// <summary>
+    /// Abort this transaction and deallocate all resources associated with it (including databases).
+    /// </summary>
+    /// <param name="disposing">True if called from Dispose.</param>
+    private void Dispose(bool disposing)
+    {
+        if (_handle == 0)
+            return;
+
+        Environment.Disposing -= Dispose;
+        if (ParentTransaction != null)
         {
-            if (!IsReadOnly)
-                throw new InvalidOperationException("Can't reset non-readonly transaction");
-
-            mdb_txn_reset(_handle);
-            State = LightningTransactionState.Reseted;
+            ParentTransaction.Disposing -= Dispose;
+            ParentTransaction.StateChanging -= OnParentStateChanging;
         }
 
-        /// <summary>
-        /// Renew current transaction.
-        /// </summary>
-        public MDBResultCode Renew()
+        Disposing?.Invoke();
+
+        if (State is LightningTransactionState.Active or LightningTransactionState.Reset)
+            Abort();
+
+        _handle = 0;
+
+        if (disposing)
         {
-            if (!IsReadOnly)
-                throw new InvalidOperationException("Can't renew non-readonly transaction");
-
-            if (State != LightningTransactionState.Reseted)
-                throw new InvalidOperationException("Transaction should be reset first");
-
-            var result = mdb_txn_renew(_handle);
-            State = LightningTransactionState.Active;
-            return result;
+            GC.SuppressFinalize(this);
         }
+    }
 
-        /// <summary>
-        /// Commit all the operations of a transaction into the database.
-        /// All cursors opened within the transaction will be closed by this call. 
-        /// The cursors and transaction handle will be freed and must not be used again after this call.
-        /// </summary>
-        public MDBResultCode Commit()
-        {
-            State = LightningTransactionState.Commited;
-            StateChanging?.Invoke(State);
-            return mdb_txn_commit(_handle);
-        }
+    /// <summary>
+    /// Dispose this transaction and deallocate all resources associated with it (including databases).
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+    }
 
-        /// <summary>
-        /// Abandon all the operations of the transaction instead of saving them.
-        /// All cursors opened within the transaction will be closed by this call.
-        /// The cursors and transaction handle will be freed and must not be used again after this call.
-        /// </summary>
-        public void Abort()
-        {
-            State = LightningTransactionState.Aborted;
-            StateChanging?.Invoke(State);
-            mdb_txn_abort(_handle);
-        }
+    ~LightningTransaction()
+    {
+        Dispose(false);
+    }
 
-        /// <summary>
-        /// The number of items in the database.
-        /// </summary>
-        /// <param name="db">The database we are counting items in.</param>
-        /// <returns>The number of items.</returns>
-        public long GetEntriesCount(LightningDatabase db)
-        {
-            mdb_stat(_handle, db.Handle(), out var stat).ThrowOnError();
+    public override int GetHashCode()
+    {
+        return _originalHandle.GetHashCode();
+    }
 
-            return stat.ms_entries;
-        }
-
-        /// <summary>
-        /// Environment in which the transaction was opened.
-        /// </summary>
-        public LightningEnvironment Environment { get; }
-
-        /// <summary>
-        /// Parent transaction of this transaction.
-        /// </summary>
-        public LightningTransaction ParentTransaction { get; }
-
-        /// <summary>
-        /// Whether this transaction is read-only.
-        /// </summary>
-        public bool IsReadOnly { get; }
-
-        /// <summary>
-        /// Abort this transaction and deallocate all resources associated with it (including databases).
-        /// </summary>
-        /// <param name="disposing">True if called from Dispose.</param>
-        private void Dispose(bool disposing)
-        {
-            if (_handle == IntPtr.Zero)
-                return;
-
-            Environment.Disposing -= Dispose;
-            if (ParentTransaction != null)
-            {
-                ParentTransaction.Disposing -= Dispose;
-                ParentTransaction.StateChanging -= OnParentStateChanging;
-            }
-
-            Disposing?.Invoke();
-
-            if (State == LightningTransactionState.Active || State == LightningTransactionState.Reseted)
-                Abort();
-
-            _handle = IntPtr.Zero;
-
-            if (disposing)
-            {
-                GC.SuppressFinalize(this);
-            }
-        }
-
-        /// <summary>
-        /// Dispose this transaction and deallocate all resources associated with it (including databases).
-        /// </summary>
-        public void Dispose()
-        {
-            Dispose(true);
-        }
-
-        ~LightningTransaction()
-        {
-            Dispose(false);
-        }
-
-        public override int GetHashCode()
-        {
-            return _originalHandle.GetHashCode();
-        }
-
-        public override bool Equals(object obj)
-        {
-            var tran = obj as LightningTransaction;
-            if (tran == null)
-                return false;
-
-            return _handle.Equals(tran._handle);
-        }
+    public override bool Equals(object obj)
+    {
+        var tran = obj as LightningTransaction;
+        return tran != null && _handle.Equals(tran._handle);
     }
 }

--- a/src/LightningDB/LightningTransaction.cs
+++ b/src/LightningDB/LightningTransaction.cs
@@ -14,8 +14,8 @@ namespace LightningDB
         /// </summary>
         public const TransactionBeginFlags DefaultTransactionBeginFlags = TransactionBeginFlags.None;
 
-        private IntPtr _handle;
-        private readonly IntPtr _originalHandle;
+        private nint _handle;
+        private readonly nint _originalHandle;
 
         /// <summary>
         /// Created new instance of LightningTransaction
@@ -41,7 +41,7 @@ namespace LightningDB
             _originalHandle = _handle;
         }
 
-        public IntPtr Handle()
+        public nint Handle()
         {
             return _handle;
         }
@@ -322,7 +322,7 @@ namespace LightningDB
         {
             mdb_stat(_handle, db.Handle(), out var stat).ThrowOnError();
 
-            return stat.ms_entries.ToInt64();
+            return stat.ms_entries;
         }
 
         /// <summary>

--- a/src/LightningDB/LightningTransactionState.cs
+++ b/src/LightningDB/LightningTransactionState.cs
@@ -1,28 +1,27 @@
-﻿namespace LightningDB
+﻿namespace LightningDB;
+
+/// <summary>
+/// Transaction state.
+/// </summary>
+public enum LightningTransactionState
 {
     /// <summary>
-    /// Transaction state.
+    /// Transaction is currently active.
     /// </summary>
-    public enum LightningTransactionState
-    {
-        /// <summary>
-        /// Transaction is currently active.
-        /// </summary>
-        Active,
+    Active,
 
-        /// <summary>
-        /// Transaction is currently reseted.
-        /// </summary>
-        Reseted,
+    /// <summary>
+    /// Transaction is currently reset.
+    /// </summary>
+    Reset,
 
-        /// <summary>
-        /// Transaction is aborted.
-        /// </summary>
-        Aborted,
+    /// <summary>
+    /// Transaction is aborted.
+    /// </summary>
+    Aborted,
 
-        /// <summary>
-        /// Transaction is commited.
-        /// </summary>
-        Commited
-    }
+    /// <summary>
+    /// Transaction is committed.
+    /// </summary>
+    Committed
 }

--- a/src/LightningDB/LightningVersionInfo.cs
+++ b/src/LightningDB/LightningVersionInfo.cs
@@ -1,47 +1,46 @@
 ﻿using System.Runtime.InteropServices;
 using static LightningDB.Native.Lmdb;
 
-namespace LightningDB
+namespace LightningDB;
+
+/// <summary>
+/// Represents lmdb version information.
+/// </summary>
+public class LightningVersionInfo
 {
-    /// <summary>
-    /// Represents lmdb version information.
-    /// </summary>
-    public class LightningVersionInfo
+    internal static LightningVersionInfo Get()
     {
-        internal static LightningVersionInfo Get()
+        var version = mdb_version(out var major, out var minor, out var patch);
+        return new LightningVersionInfo
         {
-            var version = mdb_version(out var major, out var minor, out var patch);
-            return new LightningVersionInfo
-            {
-                Version = Marshal.PtrToStringAnsi(version),
-                Major = major,
-                Minor = minor,
-                Patch = patch
-            };
-        }
-
-        private LightningVersionInfo()
-        {
-        }
-
-        /// <summary>
-        /// Major version number.
-        /// </summary>
-        public int Major { get; private set; }
-
-        /// <summary>
-        /// Minor version number.
-        /// </summary>
-        public int Minor { get; private set; }
-
-        /// <summary>
-        /// Patch version number.
-        /// </summary>
-        public int Patch { get; private set; }
-
-        /// <summary>
-        /// Version string.
-        /// </summary>
-        public string Version { get; private set; }
+            Version = Marshal.PtrToStringAnsi(version),
+            Major = major,
+            Minor = minor,
+            Patch = patch
+        };
     }
+
+    private LightningVersionInfo()
+    {
+    }
+
+    /// <summary>
+    /// Major version number.
+    /// </summary>
+    public int Major { get; private set; }
+
+    /// <summary>
+    /// Minor version number.
+    /// </summary>
+    public int Minor { get; private set; }
+
+    /// <summary>
+    /// Patch version number.
+    /// </summary>
+    public int Patch { get; private set; }
+
+    /// <summary>
+    /// Version string.
+    /// </summary>
+    public string Version { get; private set; }
 }

--- a/src/LightningDB/MDBResultCode.cs
+++ b/src/LightningDB/MDBResultCode.cs
@@ -1,126 +1,125 @@
-namespace LightningDB
+namespace LightningDB;
+
+public enum MDBResultCode
 {
-    public enum MDBResultCode : int
-    {
-        /// <summary>
-        /// Successful result
-        /// </summary>
-        Success = 0,
-        /// <summary>
-        /// key/data pair already exists
-        /// </summary>
-        KeyExist = -30799,
-        /// <summary>
-        /// key/data pair not found (EOF)
-        /// </summary>
-        NotFound = -30798,
-        /// <summary>
-        /// Requested page not found - this usually indicates corruption
-        /// </summary>
-        PageNotFound = -30797,
-        /// <summary>
-        /// Located page was wrong type
-        /// </summary>
-        Corrupted = -30796,
-        /// <summary>
-        /// Update of meta page failed or environment had fatal error
-        /// </summary>
-        Panic = -30795,
-        /// <summary>
-        /// Environment version mismatch
-        /// </summary>
-        VersionMismatch = -30794,
-        /// <summary>
-        /// File is not a valid LMDB file
-        /// </summary>
-        Invalid = -30793,
-        /// <summary>
-        /// Environment mapsize reached
-        /// </summary>
-        MapFull = -30792,
-        /// <summary>
-        /// Environment maxdbs reached
-        /// </summary>
-        DbsFull = -30791,
-        /// <summary>
-        /// Environment maxreaders reached
-        /// </summary>
-        ReadersFull = -30790,
-        /// <summary>
-        /// Too many TLS keys in use - Windows only
-        /// </summary>
-        TLSFull = -30789,
-        /// <summary>
-        /// Txn has too many dirty pages
-        /// </summary>
-        TxnFull = -30788,
-        /// <summary>
-        /// Cursor stack too deep - internal error
-        /// </summary>
-        CursorFull = -30787,
-        /// <summary>
-        /// Page has not enough space - internal error
-        /// </summary>
-        PageFull = -30786,
-        /// <summary>
-        /// Database contents grew beyond environment mapsize
-        /// </summary>
-        MapResized = -30785,
-        /// <summary>
-        /// Operation and DB incompatible, or DB type changed. This can mean:
-        ///	- The operation expects an #MDB_DUPSORT / #MDB_DUPFIXED database.
-        /// - Opening a named DB when the unnamed DB has #MDB_DUPSORT / #MDB_INTEGERKEY.
-        /// - Accessing a data record as a database, or vice versa.
-        /// - The database was dropped and recreated with different flags.
-        /// </summary>
-        Incompatible = -30784,
-        /// <summary>
-        /// Invalid reuse of reader locktable slot
-        /// </summary>
-        BadRSlot = -30783,
-        /// <summary>
-        /// Transaction must abort, has a child, or is invalid
-        /// </summary>
-        BadTxn = -30782,
-        /// <summary>
-        /// Unsupported size of key/DB name/data, or wrong DUPFIXED size
-        /// </summary>
-        BadValSize = -30781,
-        /// <summary>
-        /// The specified DBI was changed unexpectedly
-        /// </summary>
-        BadDBI = -30780,
-        /// <summary>
-        /// Unexpected problem - txn should abort
-        /// </summary>
-        Problem = -30779,
-        /// <summary>
-        /// ENOENT error from C-runtime
-        /// </summary>
-        FileNotFound = 2,
-        /// <summary>
-        /// EIO error from C-runtime
-        /// </summary>
-        AccessDenied = 5,
-        /// <summary>
-        /// ENOMEM error from C-runtime
-        /// </summary>
-        InvalidAccess = 12,
-        /// <summary>
-        /// EACCES error from C-runtime
-        /// </summary>
-        InvalidData = 13,
-        /// <summary>
-        /// EBUSY error from C-runtime
-        /// </summary>
-        CurrentDirectory = 16,
-        /// <summary>
-        /// EINVAL error from C-runtime
-        /// </summary>
-        BadCommand = 22, 
-        /// <summary>
-        /// ENOSPC error from C-runtime
-        /// </summary>
-        OutOfPaper = 28
-    }
+    /// <summary>
+    /// Successful result
+    /// </summary>
+    Success = 0,
+    /// <summary>
+    /// key/data pair already exists
+    /// </summary>
+    KeyExist = -30799,
+    /// <summary>
+    /// key/data pair not found (EOF)
+    /// </summary>
+    NotFound = -30798,
+    /// <summary>
+    /// Requested page not found - this usually indicates corruption
+    /// </summary>
+    PageNotFound = -30797,
+    /// <summary>
+    /// Located page was wrong type
+    /// </summary>
+    Corrupted = -30796,
+    /// <summary>
+    /// Update of meta page failed or environment had fatal error
+    /// </summary>
+    Panic = -30795,
+    /// <summary>
+    /// Environment version mismatch
+    /// </summary>
+    VersionMismatch = -30794,
+    /// <summary>
+    /// File is not a valid LMDB file
+    /// </summary>
+    Invalid = -30793,
+    /// <summary>
+    /// Environment mapsize reached
+    /// </summary>
+    MapFull = -30792,
+    /// <summary>
+    /// Environment maxdbs reached
+    /// </summary>
+    DbsFull = -30791,
+    /// <summary>
+    /// Environment maxreaders reached
+    /// </summary>
+    ReadersFull = -30790,
+    /// <summary>
+    /// Too many TLS keys in use - Windows only
+    /// </summary>
+    TLSFull = -30789,
+    /// <summary>
+    /// Txn has too many dirty pages
+    /// </summary>
+    TxnFull = -30788,
+    /// <summary>
+    /// Cursor stack too deep - internal error
+    /// </summary>
+    CursorFull = -30787,
+    /// <summary>
+    /// Page has not enough space - internal error
+    /// </summary>
+    PageFull = -30786,
+    /// <summary>
+    /// Database contents grew beyond environment mapsize
+    /// </summary>
+    MapResized = -30785,
+    /// <summary>
+    /// Operation and DB incompatible, or DB type changed. This can mean:
+    ///	- The operation expects an #MDB_DUPSORT / #MDB_DUPFIXED database.
+    /// - Opening a named DB when the unnamed DB has #MDB_DUPSORT / #MDB_INTEGERKEY.
+    /// - Accessing a data record as a database, or vice versa.
+    /// - The database was dropped and recreated with different flags.
+    /// </summary>
+    Incompatible = -30784,
+    /// <summary>
+    /// Invalid reuse of reader locktable slot
+    /// </summary>
+    BadRSlot = -30783,
+    /// <summary>
+    /// Transaction must abort, has a child, or is invalid
+    /// </summary>
+    BadTxn = -30782,
+    /// <summary>
+    /// Unsupported size of key/DB name/data, or wrong DUPFIXED size
+    /// </summary>
+    BadValSize = -30781,
+    /// <summary>
+    /// The specified DBI was changed unexpectedly
+    /// </summary>
+    BadDBI = -30780,
+    /// <summary>
+    /// Unexpected problem - txn should abort
+    /// </summary>
+    Problem = -30779,
+    /// <summary>
+    /// ENOENT error from C-runtime
+    /// </summary>
+    FileNotFound = 2,
+    /// <summary>
+    /// EIO error from C-runtime
+    /// </summary>
+    AccessDenied = 5,
+    /// <summary>
+    /// ENOMEM error from C-runtime
+    /// </summary>
+    InvalidAccess = 12,
+    /// <summary>
+    /// EACCES error from C-runtime
+    /// </summary>
+    InvalidData = 13,
+    /// <summary>
+    /// EBUSY error from C-runtime
+    /// </summary>
+    CurrentDirectory = 16,
+    /// <summary>
+    /// EINVAL error from C-runtime
+    /// </summary>
+    BadCommand = 22, 
+    /// <summary>
+    /// ENOSPC error from C-runtime
+    /// </summary>
+    OutOfPaper = 28
 }

--- a/src/LightningDB/MDBValue.cs
+++ b/src/LightningDB/MDBValue.cs
@@ -1,51 +1,50 @@
 ﻿using System;
 
-namespace LightningDB
+namespace LightningDB;
+
+/// <summary>
+/// A managed version of the native MDB_val type
+/// </summary>
+/// <remarks>
+/// For Performance and Correctness, the layout of this struct must not be changed. 
+/// This struct is blittable and is marshalled directly to Native code via
+/// P/Invoke.
+/// </remarks>
+public unsafe struct MDBValue
 {
-    /// <summary>
-    /// A managed version of the native MDB_val type
-    /// </summary>
     /// <remarks>
-    /// For Performance and Correctness, the layout of this struct must not be changed. 
-    /// This struct is blittable and is marshalled directly to Native code via
-    /// P/Invoke.
+    /// We only expose this shape constructor to basically force you to use
+    /// a fixed statement to obtain the pointer. If we accepted a Span or 
+    /// ReadOnlySpan here, we would have to do scarier things to pin/unpin
+    /// the buffer. Since this library is geared towards safe and easy usage,
+    /// this way somewhat forces you onto the correct path.
+    /// 
     /// </remarks>
-    public unsafe struct MDBValue
+    /// <param name="bufferSize">The length of the buffer</param>
+    /// <param name="pinnedOrStackAllocBuffer">A pointer to a buffer. 
+    /// The underlying memory may be managed(an array), unmanaged or stack-allocated.
+    /// If it is managed, it **MUST** be pinned via either GCHandle.Alloc or a fixed statement
+    /// </param>
+    internal MDBValue(int bufferSize, byte* pinnedOrStackAllocBuffer)
     {
-        /// <remarks>
-        /// We only expose this shape constructor to basically force you to use
-        /// a fixed statement to obtain the pointer. If we accepted a Span or 
-        /// ReadOnlySpan here, we would have to do scarier things to pin/unpin
-        /// the buffer. Since this library is geared towards safe and easy usage,
-        /// this way somewhat forces you onto the correct path.
-        /// 
-        /// </remarks>
-        /// <param name="bufferSize">The length of the buffer</param>
-        /// <param name="pinnedOrStackAllocBuffer">A pointer to a buffer. 
-        /// The underlying memory may be managed(an array), unmanaged or stack-allocated.
-        /// If it is managed, it **MUST** be pinned via either GCHandle.Alloc or a fixed statement
-        /// </param>
-        internal MDBValue(int bufferSize, byte* pinnedOrStackAllocBuffer)
-        {
-            size = bufferSize;
-            data = pinnedOrStackAllocBuffer;
-        }
-        //DO NOT REORDER
-        internal nint size;
-
-        //DO NOT REORDER
-        internal byte* data;
-
-        /// <summary>
-        /// Gets a span representation of the buffer
-        /// </summary>
-        public ReadOnlySpan<byte> AsSpan() => new (data, checked((int)size));
-
-        /// <summary>
-        /// Copies the data of the buffer to a new array
-        /// </summary>
-        /// <returns>A newly allocated array containing data copied from the de-referenced data pointer</returns>
-        /// <remarks>Equivalent to AsSpan().ToArray() but makes intent a little more clear</remarks>
-        public byte[] CopyToNewArray() => AsSpan().ToArray();
+        size = bufferSize;
+        data = pinnedOrStackAllocBuffer;
     }
+    //DO NOT REORDER
+    internal nint size;
+
+    //DO NOT REORDER
+    internal byte* data;
+
+    /// <summary>
+    /// Gets a span representation of the buffer
+    /// </summary>
+    public ReadOnlySpan<byte> AsSpan() => new (data, (int)size);
+
+    /// <summary>
+    /// Copies the data of the buffer to a new array
+    /// </summary>
+    /// <returns>A newly allocated array containing data copied from the de-referenced data pointer</returns>
+    /// <remarks>Equivalent to AsSpan().ToArray() but makes intent a little more clear</remarks>
+    public byte[] CopyToNewArray() => AsSpan().ToArray();
 }

--- a/src/LightningDB/MDBValue.cs
+++ b/src/LightningDB/MDBValue.cs
@@ -27,11 +27,11 @@ namespace LightningDB
         /// </param>
         internal MDBValue(int bufferSize, byte* pinnedOrStackAllocBuffer)
         {
-            this.size = (IntPtr)bufferSize;
-            this.data = pinnedOrStackAllocBuffer;
+            size = bufferSize;
+            data = pinnedOrStackAllocBuffer;
         }
         //DO NOT REORDER
-        internal IntPtr size;
+        internal nint size;
 
         //DO NOT REORDER
         internal byte* data;
@@ -39,7 +39,7 @@ namespace LightningDB
         /// <summary>
         /// Gets a span representation of the buffer
         /// </summary>
-        public ReadOnlySpan<byte> AsSpan() => new ReadOnlySpan<byte>(data, checked((int)size));
+        public ReadOnlySpan<byte> AsSpan() => new (data, checked((int)size));
 
         /// <summary>
         /// Copies the data of the buffer to a new array

--- a/src/LightningDB/Native/CompareFunction.cs
+++ b/src/LightningDB/Native/CompareFunction.cs
@@ -1,7 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 
-namespace LightningDB.Native
-{
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate int CompareFunction(ref MDBValue left, ref MDBValue right);
-}
+namespace LightningDB.Native;
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+public delegate int CompareFunction(ref MDBValue left, ref MDBValue right);

--- a/src/LightningDB/Native/Lmdb.cs
+++ b/src/LightningDB/Native/Lmdb.cs
@@ -3,7 +3,159 @@ using System.Runtime.InteropServices;
 
 namespace LightningDB.Native
 {
-    public static class Lmdb
+    
+    #if NET7_0
+    using System.Runtime.CompilerServices;
+    public static partial class Lmdb
+    {
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_env_create(out nint env); 
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial void mdb_env_close(nint env);
+        
+        [LibraryImport(MDB_DLL_NAME, StringMarshalling = StringMarshalling.Utf8)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_env_open(nint env, string path, EnvironmentOpenFlags flags, UnixAccessMode mode);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_env_set_mapsize(nint env, nint size);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_env_get_maxreaders(nint env, out uint readers);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_env_set_maxreaders(nint env, uint readers);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_env_set_maxdbs(nint env, uint dbs);
+        
+        [LibraryImport(MDB_DLL_NAME, StringMarshalling = StringMarshalling.Utf8)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_dbi_open(nint txn, string name, DatabaseOpenFlags flags, out uint db);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial void mdb_dbi_close(nint env, uint dbi);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_drop(nint txn, uint dbi, [MarshalAs(UnmanagedType.I1)] bool del);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_txn_begin(nint env, nint parent, TransactionBeginFlags flags, out nint txn);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_txn_commit(nint txn);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial void mdb_txn_abort(nint txn);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial void mdb_txn_reset(nint txn);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_txn_renew(nint txn);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial nint mdb_version(out int major, out int minor, out int patch);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial nint mdb_strerror(int err);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_stat(nint txn, uint dbi, out MDBStat stat);
+        
+        [LibraryImport(MDB_DLL_NAME, StringMarshalling = StringMarshalling.Utf8)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_env_copy(nint env, string path);
+        
+        [LibraryImport(MDB_DLL_NAME, StringMarshalling = StringMarshalling.Utf8)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_env_copy2(nint env, string path, EnvironmentCopyFlags copyFlags);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_env_info(nint env, out MDBEnvInfo stat);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_env_stat(nint env, out MDBStat stat);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_env_sync(nint env, [MarshalAs(UnmanagedType.I1)] bool force);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_get(nint txn, uint dbi, ref MDBValue key, out MDBValue data);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_put(nint txn, uint dbi, ref MDBValue key, ref MDBValue data, PutOptions flags);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_del(nint txn, uint dbi, ref MDBValue key, ref MDBValue data);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_del(nint txn, uint dbi, ref MDBValue key, nint data);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_cursor_open(nint txn, uint dbi, out nint cursor);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial void mdb_cursor_close(nint cursor);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_cursor_renew(nint txn, nint cursor);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_cursor_get(nint cursor, ref MDBValue key, ref MDBValue data, CursorOperation op);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_cursor_put(nint cursor, ref MDBValue key, ref MDBValue mdbValue, CursorPutOptions flags);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_cursor_del(nint cursor, CursorDeleteOption flags);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_set_compare(nint txn, uint dbi, CompareFunction cmp);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_set_dupsort(nint txn, uint dbi, CompareFunction cmp);
+        
+        [LibraryImport(MDB_DLL_NAME)]
+        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+        public static partial MDBResultCode mdb_cursor_put(nint cursor, ref MDBValue key, MDBValue[] value, CursorPutOptions flags);
+    }
+    #endif
+    
+    #region DllImport
+    public static partial class Lmdb
     {
         private const string MDB_DLL_NAME = "lmdb";
         /// <summary>
@@ -16,27 +168,27 @@ namespace LightningDB.Native
         /// </summary>
         public const int MDB_DUPFIXED = 0x10;
 
-        public static MDBResultCode mdb_env_set_mapsize(IntPtr env, long size)
+        public static MDBResultCode mdb_env_set_mapsize(nint env, long size)
         {
             return mdb_env_set_mapsize(env, new IntPtr(size));
         }
 
-        public static MDBResultCode mdb_put(IntPtr txn, uint dbi, MDBValue key, MDBValue value, PutOptions flags)
+        public static MDBResultCode mdb_put(nint txn, uint dbi, MDBValue key, MDBValue value, PutOptions flags)
         {
             return mdb_put(txn, dbi, ref key, ref value, flags);
         }
 
-        public static MDBResultCode mdb_del(IntPtr txn, uint dbi, MDBValue key, MDBValue value)
+        public static MDBResultCode mdb_del(nint txn, uint dbi, MDBValue key, MDBValue value)
         {
             return mdb_del(txn, dbi, ref key, ref value);
         }
 
-        public static MDBResultCode mdb_del(IntPtr txn, uint dbi, MDBValue key)
+        public static MDBResultCode mdb_del(nint txn, uint dbi, MDBValue key)
         {
-            return mdb_del(txn, dbi, ref key, IntPtr.Zero);
+            return mdb_del(txn, dbi, ref key,IntPtr.Zero);
         }
 
-        public static MDBResultCode mdb_cursor_put(IntPtr cursor, MDBValue key, MDBValue value, CursorPutOptions flags)
+        public static MDBResultCode mdb_cursor_put(nint cursor, MDBValue key, MDBValue value, CursorPutOptions flags)
         {
             return mdb_cursor_put(cursor, ref key, ref value, flags);
         }
@@ -49,121 +201,123 @@ namespace LightningDB.Native
         /// <param name="key"><see cref="MDBValue"/> key</param>
         /// <param name="data">This span must be pinned or stackalloc memory</param>
         /// <param name="flags"><see cref="CursorPutOptions"/></param>
-        public static MDBResultCode mdb_cursor_put(IntPtr cursor, ref MDBValue key, ref Span<MDBValue> data,
+        public static MDBResultCode mdb_cursor_put(nint cursor, ref MDBValue key, ref Span<MDBValue> data,
             CursorPutOptions flags)
         {
             ref var dataRef = ref MemoryMarshal.GetReference(data);
             return mdb_cursor_put(cursor, ref key, ref dataRef, flags);
         }
 
+    #if !NET7_0
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_env_create(out IntPtr env);
+        public static extern MDBResultCode mdb_env_create(out nint env);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void mdb_env_close(IntPtr env);
+        public static extern void mdb_env_close(nint env);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern MDBResultCode mdb_env_open(IntPtr env, string path, EnvironmentOpenFlags flags,
+        internal static extern MDBResultCode mdb_env_open(nint env, string path, EnvironmentOpenFlags flags,
             UnixAccessMode mode);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_env_set_mapsize(IntPtr env, IntPtr size);
+        public static extern MDBResultCode mdb_env_set_mapsize(nint env, nint size);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_env_get_maxreaders(IntPtr env, out uint readers);
+        public static extern MDBResultCode mdb_env_get_maxreaders(nint env, out uint readers);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_env_set_maxreaders(IntPtr env, uint readers);
+        public static extern MDBResultCode mdb_env_set_maxreaders(nint env, uint readers);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_env_set_maxdbs(IntPtr env, uint dbs);
+        public static extern MDBResultCode mdb_env_set_maxdbs(nint env, uint dbs);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_dbi_open(IntPtr txn, string name, DatabaseOpenFlags flags, out uint db);
+        public static extern MDBResultCode mdb_dbi_open(nint txn, string name, DatabaseOpenFlags flags, out uint db);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void mdb_dbi_close(IntPtr env, uint dbi);
+        public static extern void mdb_dbi_close(nint env, uint dbi);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_drop(IntPtr txn, uint dbi, bool del);
+        public static extern MDBResultCode mdb_drop(nint txn, uint dbi, bool del);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_txn_begin(IntPtr env, IntPtr parent, TransactionBeginFlags flags, out IntPtr txn);
+        public static extern MDBResultCode mdb_txn_begin(nint env, nint parent, TransactionBeginFlags flags, out nint txn);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_txn_commit(IntPtr txn);
+        public static extern MDBResultCode mdb_txn_commit(nint txn);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void mdb_txn_abort(IntPtr txn);
+        public static extern void mdb_txn_abort(nint txn);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void mdb_txn_reset(IntPtr txn);
+        public static extern void mdb_txn_reset(nint txn);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_txn_renew(IntPtr txn);
+        public static extern MDBResultCode mdb_txn_renew(nint txn);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr mdb_version(out int major, out int minor, out int patch);
+        public static extern nint mdb_version(out int major, out int minor, out int patch);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr mdb_strerror(int err);
+        public static extern nint mdb_strerror(int err);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_stat(IntPtr txn, uint dbi, out MDBStat stat);
+        public static extern MDBResultCode mdb_stat(nint txn, uint dbi, out MDBStat stat);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_env_copy(IntPtr env, string path);
+        public static extern MDBResultCode mdb_env_copy(nint env, string path);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_env_copy2(IntPtr env, string path, EnvironmentCopyFlags copyFlags);
+        public static extern MDBResultCode mdb_env_copy2(nint env, string path, EnvironmentCopyFlags copyFlags);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_env_info(IntPtr env, out MDBEnvInfo stat);
+        public static extern MDBResultCode mdb_env_info(nint env, out MDBEnvInfo stat);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_env_stat(IntPtr env, out MDBStat stat);
+        public static extern MDBResultCode mdb_env_stat(nint env, out MDBStat stat);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_env_sync(IntPtr env, bool force);
+        public static extern MDBResultCode mdb_env_sync(nint env, bool force);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_get(IntPtr txn, uint dbi, ref MDBValue key, out MDBValue data);
+        public static extern MDBResultCode mdb_get(nint txn, uint dbi, ref MDBValue key, out MDBValue data);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_put(IntPtr txn, uint dbi, ref MDBValue key, ref MDBValue data, PutOptions flags);
+        public static extern MDBResultCode mdb_put(nint txn, uint dbi, ref MDBValue key, ref MDBValue data, PutOptions flags);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_del(IntPtr txn, uint dbi, ref MDBValue key, ref MDBValue data);
+        public static extern MDBResultCode mdb_del(nint txn, uint dbi, ref MDBValue key, ref MDBValue data);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_del(IntPtr txn, uint dbi, ref MDBValue key, IntPtr data);
+        public static extern MDBResultCode mdb_del(nint txn, uint dbi, ref MDBValue key, nint data);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_cursor_open(IntPtr txn, uint dbi, out IntPtr cursor);
+        public static extern MDBResultCode mdb_cursor_open(nint txn, uint dbi, out nint cursor);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void mdb_cursor_close(IntPtr cursor);
+        public static extern void mdb_cursor_close(nint cursor);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_cursor_renew(IntPtr txn, IntPtr cursor);
+        public static extern MDBResultCode mdb_cursor_renew(nint txn, nint cursor);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_cursor_get(IntPtr cursor, ref MDBValue key, ref MDBValue data, CursorOperation op);
+        public static extern MDBResultCode mdb_cursor_get(nint cursor, ref MDBValue key, ref MDBValue data, CursorOperation op);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_cursor_put(IntPtr cursor, ref MDBValue key, ref MDBValue mdbValue, CursorPutOptions flags);
+        public static extern MDBResultCode mdb_cursor_put(nint cursor, ref MDBValue key, ref MDBValue mdbValue, CursorPutOptions flags);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_cursor_del(IntPtr cursor, CursorDeleteOption flags);
+        public static extern MDBResultCode mdb_cursor_del(nint cursor, CursorDeleteOption flags);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_set_compare(IntPtr txn, uint dbi, CompareFunction cmp);
+        public static extern MDBResultCode mdb_set_compare(nint txn, uint dbi, CompareFunction cmp);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_set_dupsort(IntPtr txn, uint dbi, CompareFunction cmp);
+        public static extern MDBResultCode mdb_set_dupsort(nint txn, uint dbi, CompareFunction cmp);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_cursor_put(IntPtr cursor, ref MDBValue key, MDBValue[] value, CursorPutOptions flags);
+        public static extern MDBResultCode mdb_cursor_put(nint cursor, ref MDBValue key, MDBValue[] value, CursorPutOptions flags);
+    #endif 
 
 #if NETCOREAPP3_1_OR_GREATER
 
@@ -185,7 +339,7 @@ namespace LightningDB.Native
             }
         }
 
-        private static IntPtr DllImportResolver(string libraryName, System.Reflection.Assembly assembly, DllImportSearchPath? searchPath)
+        private static nint DllImportResolver(string libraryName, System.Reflection.Assembly assembly, DllImportSearchPath? searchPath)
         {
             if (libraryName == MDB_DLL_NAME)
             {
@@ -195,4 +349,5 @@ namespace LightningDB.Native
         }
 #endif
     }
+    #endregion
 }

--- a/src/LightningDB/Native/Lmdb.cs
+++ b/src/LightningDB/Native/Lmdb.cs
@@ -1,214 +1,213 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-namespace LightningDB.Native
+namespace LightningDB.Native;
+
+#if NET7_0
+using System.Runtime.CompilerServices;
+public static partial class Lmdb
 {
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_env_create(out nint env); 
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial void mdb_env_close(nint env);
+        
+    [LibraryImport(MDB_DLL_NAME, StringMarshalling = StringMarshalling.Utf8)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_env_open(nint env, string path, EnvironmentOpenFlags flags, UnixAccessMode mode);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_env_set_mapsize(nint env, nint size);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_env_get_maxreaders(nint env, out uint readers);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_env_set_maxreaders(nint env, uint readers);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_env_set_maxdbs(nint env, uint dbs);
+        
+    [LibraryImport(MDB_DLL_NAME, StringMarshalling = StringMarshalling.Utf8)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_dbi_open(nint txn, string name, DatabaseOpenFlags flags, out uint db);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial void mdb_dbi_close(nint env, uint dbi);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_drop(nint txn, uint dbi, [MarshalAs(UnmanagedType.I1)] bool del);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_txn_begin(nint env, nint parent, TransactionBeginFlags flags, out nint txn);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_txn_commit(nint txn);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial void mdb_txn_abort(nint txn);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial void mdb_txn_reset(nint txn);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_txn_renew(nint txn);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial nint mdb_version(out int major, out int minor, out int patch);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial nint mdb_strerror(int err);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_stat(nint txn, uint dbi, out MDBStat stat);
+        
+    [LibraryImport(MDB_DLL_NAME, StringMarshalling = StringMarshalling.Utf8)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_env_copy(nint env, string path);
+        
+    [LibraryImport(MDB_DLL_NAME, StringMarshalling = StringMarshalling.Utf8)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_env_copy2(nint env, string path, EnvironmentCopyFlags copyFlags);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_env_info(nint env, out MDBEnvInfo stat);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_env_stat(nint env, out MDBStat stat);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_env_sync(nint env, [MarshalAs(UnmanagedType.I1)] bool force);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_get(nint txn, uint dbi, ref MDBValue key, out MDBValue data);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_put(nint txn, uint dbi, ref MDBValue key, ref MDBValue data, PutOptions flags);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_del(nint txn, uint dbi, ref MDBValue key, ref MDBValue data);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_del(nint txn, uint dbi, ref MDBValue key, nint data);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_cursor_open(nint txn, uint dbi, out nint cursor);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial void mdb_cursor_close(nint cursor);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_cursor_renew(nint txn, nint cursor);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_cursor_get(nint cursor, ref MDBValue key, ref MDBValue data, CursorOperation op);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_cursor_put(nint cursor, ref MDBValue key, ref MDBValue mdbValue, CursorPutOptions flags);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_cursor_del(nint cursor, CursorDeleteOption flags);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_set_compare(nint txn, uint dbi, CompareFunction cmp);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_set_dupsort(nint txn, uint dbi, CompareFunction cmp);
+        
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
+    public static partial MDBResultCode mdb_cursor_put(nint cursor, ref MDBValue key, MDBValue[] value, CursorPutOptions flags);
+}
+#endif
     
-    #if NET7_0
-    using System.Runtime.CompilerServices;
-    public static partial class Lmdb
+#region DllImport
+public static partial class Lmdb
+{
+    private const string MDB_DLL_NAME = "lmdb";
+    /// <summary>
+    /// Duplicate keys may be used in the database. (Or, from another perspective, keys may have multiple data items, stored in sorted order.) By default keys must be unique and may have only a single data item.
+    /// </summary>
+    public const int MDB_DUPSORT = 0x04;
+
+    /// <summary>
+    /// This flag may only be used in combination with MDB_DUPSORT. This option tells the library that the data items for this database are all the same size, which allows further optimizations in storage and retrieval. When all data items are the same size, the MDB_GET_MULTIPLE and MDB_NEXT_MULTIPLE cursor operations may be used to retrieve multiple items at once.
+    /// </summary>
+    public const int MDB_DUPFIXED = 0x10;
+
+    public static MDBResultCode mdb_env_set_mapsize(nint env, long size)
     {
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_env_create(out nint env); 
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial void mdb_env_close(nint env);
-        
-        [LibraryImport(MDB_DLL_NAME, StringMarshalling = StringMarshalling.Utf8)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_env_open(nint env, string path, EnvironmentOpenFlags flags, UnixAccessMode mode);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_env_set_mapsize(nint env, nint size);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_env_get_maxreaders(nint env, out uint readers);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_env_set_maxreaders(nint env, uint readers);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_env_set_maxdbs(nint env, uint dbs);
-        
-        [LibraryImport(MDB_DLL_NAME, StringMarshalling = StringMarshalling.Utf8)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_dbi_open(nint txn, string name, DatabaseOpenFlags flags, out uint db);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial void mdb_dbi_close(nint env, uint dbi);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_drop(nint txn, uint dbi, [MarshalAs(UnmanagedType.I1)] bool del);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_txn_begin(nint env, nint parent, TransactionBeginFlags flags, out nint txn);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_txn_commit(nint txn);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial void mdb_txn_abort(nint txn);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial void mdb_txn_reset(nint txn);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_txn_renew(nint txn);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial nint mdb_version(out int major, out int minor, out int patch);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial nint mdb_strerror(int err);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_stat(nint txn, uint dbi, out MDBStat stat);
-        
-        [LibraryImport(MDB_DLL_NAME, StringMarshalling = StringMarshalling.Utf8)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_env_copy(nint env, string path);
-        
-        [LibraryImport(MDB_DLL_NAME, StringMarshalling = StringMarshalling.Utf8)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_env_copy2(nint env, string path, EnvironmentCopyFlags copyFlags);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_env_info(nint env, out MDBEnvInfo stat);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_env_stat(nint env, out MDBStat stat);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_env_sync(nint env, [MarshalAs(UnmanagedType.I1)] bool force);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_get(nint txn, uint dbi, ref MDBValue key, out MDBValue data);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_put(nint txn, uint dbi, ref MDBValue key, ref MDBValue data, PutOptions flags);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_del(nint txn, uint dbi, ref MDBValue key, ref MDBValue data);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_del(nint txn, uint dbi, ref MDBValue key, nint data);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_cursor_open(nint txn, uint dbi, out nint cursor);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial void mdb_cursor_close(nint cursor);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_cursor_renew(nint txn, nint cursor);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_cursor_get(nint cursor, ref MDBValue key, ref MDBValue data, CursorOperation op);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_cursor_put(nint cursor, ref MDBValue key, ref MDBValue mdbValue, CursorPutOptions flags);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_cursor_del(nint cursor, CursorDeleteOption flags);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_set_compare(nint txn, uint dbi, CompareFunction cmp);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_set_dupsort(nint txn, uint dbi, CompareFunction cmp);
-        
-        [LibraryImport(MDB_DLL_NAME)]
-        [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
-        public static partial MDBResultCode mdb_cursor_put(nint cursor, ref MDBValue key, MDBValue[] value, CursorPutOptions flags);
+        return mdb_env_set_mapsize(env, (nint)size);
     }
-    #endif
-    
-    #region DllImport
-    public static partial class Lmdb
+
+    public static MDBResultCode mdb_put(nint txn, uint dbi, MDBValue key, MDBValue value, PutOptions flags)
     {
-        private const string MDB_DLL_NAME = "lmdb";
-        /// <summary>
-        /// Duplicate keys may be used in the database. (Or, from another perspective, keys may have multiple data items, stored in sorted order.) By default keys must be unique and may have only a single data item.
-        /// </summary>
-        public const int MDB_DUPSORT = 0x04;
+        return mdb_put(txn, dbi, ref key, ref value, flags);
+    }
 
-        /// <summary>
-        /// This flag may only be used in combination with MDB_DUPSORT. This option tells the library that the data items for this database are all the same size, which allows further optimizations in storage and retrieval. When all data items are the same size, the MDB_GET_MULTIPLE and MDB_NEXT_MULTIPLE cursor operations may be used to retrieve multiple items at once.
-        /// </summary>
-        public const int MDB_DUPFIXED = 0x10;
+    public static MDBResultCode mdb_del(nint txn, uint dbi, MDBValue key, MDBValue value)
+    {
+        return mdb_del(txn, dbi, ref key, ref value);
+    }
 
-        public static MDBResultCode mdb_env_set_mapsize(nint env, long size)
-        {
-            return mdb_env_set_mapsize(env, new IntPtr(size));
-        }
+    public static MDBResultCode mdb_del(nint txn, uint dbi, MDBValue key)
+    {
+        return mdb_del(txn, dbi, ref key,0);
+    }
 
-        public static MDBResultCode mdb_put(nint txn, uint dbi, MDBValue key, MDBValue value, PutOptions flags)
-        {
-            return mdb_put(txn, dbi, ref key, ref value, flags);
-        }
+    public static MDBResultCode mdb_cursor_put(nint cursor, MDBValue key, MDBValue value, CursorPutOptions flags)
+    {
+        return mdb_cursor_put(cursor, ref key, ref value, flags);
+    }
 
-        public static MDBResultCode mdb_del(nint txn, uint dbi, MDBValue key, MDBValue value)
-        {
-            return mdb_del(txn, dbi, ref key, ref value);
-        }
+    /// <summary>
+    /// store multiple contiguous data elements in a single request.
+    /// May only be used with MDB_DUPFIXED.
+    /// </summary>
+    /// <param name="cursor">Pointer to cursor</param>
+    /// <param name="key"><see cref="MDBValue"/> key</param>
+    /// <param name="data">This span must be pinned or stackalloc memory</param>
+    /// <param name="flags"><see cref="CursorPutOptions"/></param>
+    public static MDBResultCode mdb_cursor_put(nint cursor, ref MDBValue key, ref Span<MDBValue> data,
+        CursorPutOptions flags)
+    {
+        ref var dataRef = ref MemoryMarshal.GetReference(data);
+        return mdb_cursor_put(cursor, ref key, ref dataRef, flags);
+    }
 
-        public static MDBResultCode mdb_del(nint txn, uint dbi, MDBValue key)
-        {
-            return mdb_del(txn, dbi, ref key,IntPtr.Zero);
-        }
-
-        public static MDBResultCode mdb_cursor_put(nint cursor, MDBValue key, MDBValue value, CursorPutOptions flags)
-        {
-            return mdb_cursor_put(cursor, ref key, ref value, flags);
-        }
-
-        /// <summary>
-        /// store multiple contiguous data elements in a single request.
-        /// May only be used with MDB_DUPFIXED.
-        /// </summary>
-        /// <param name="cursor">Pointer to cursor</param>
-        /// <param name="key"><see cref="MDBValue"/> key</param>
-        /// <param name="data">This span must be pinned or stackalloc memory</param>
-        /// <param name="flags"><see cref="CursorPutOptions"/></param>
-        public static MDBResultCode mdb_cursor_put(nint cursor, ref MDBValue key, ref Span<MDBValue> data,
-            CursorPutOptions flags)
-        {
-            ref var dataRef = ref MemoryMarshal.GetReference(data);
-            return mdb_cursor_put(cursor, ref key, ref dataRef, flags);
-        }
-
-    #if !NET7_0
+#if !NET7_0
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_env_create(out nint env);
 
@@ -317,37 +316,29 @@ namespace LightningDB.Native
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_cursor_put(nint cursor, ref MDBValue key, MDBValue[] value, CursorPutOptions flags);
-    #endif 
+#endif 
 
 #if NETCOREAPP3_1_OR_GREATER
 
-        static bool _shouldSetDllImportResolver = true;
-        static object _syncRoot = new object();
+    private static bool _shouldSetDllImportResolver = true;
+    private static readonly object _syncRoot = new();
 
-        public static void LoadWindowsAutoResizeLibrary()
+    public static void LoadWindowsAutoResizeLibrary()
+    {
+        if (!_shouldSetDllImportResolver) return;
+        lock (_syncRoot)
         {
-            if (_shouldSetDllImportResolver)
-            {
-                lock (_syncRoot)
-                {
-                    if (_shouldSetDllImportResolver)
-                    {
-                        NativeLibrary.SetDllImportResolver(System.Reflection.Assembly.GetExecutingAssembly(), DllImportResolver);
-                        _shouldSetDllImportResolver = false;
-                    }
-                }
-            }
+            if (!_shouldSetDllImportResolver) return;
+            NativeLibrary.SetDllImportResolver(System.Reflection.Assembly.GetExecutingAssembly(), DllImportResolver);
+            _shouldSetDllImportResolver = false;
         }
-
-        private static nint DllImportResolver(string libraryName, System.Reflection.Assembly assembly, DllImportSearchPath? searchPath)
-        {
-            if (libraryName == MDB_DLL_NAME)
-            {
-                return NativeLibrary.Load($"{MDB_DLL_NAME}autoresize", assembly, searchPath);
-            }
-            return IntPtr.Zero;
-        }
-#endif
     }
-    #endregion
+
+    private static nint DllImportResolver(string libraryName, System.Reflection.Assembly assembly, DllImportSearchPath? searchPath)
+    {
+        return libraryName == MDB_DLL_NAME 
+            ? NativeLibrary.Load($"{MDB_DLL_NAME}autoresize", assembly, searchPath) : 0;
+    }
+#endif
 }
+#endregion

--- a/src/LightningDB/Native/Lmdb.cs
+++ b/src/LightningDB/Native/Lmdb.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace LightningDB.Native;
 
-#if NET7_0
+#if NET7_0_OR_GREATER
 using System.Runtime.CompilerServices;
 public static partial class Lmdb
 {
@@ -153,7 +153,6 @@ public static partial class Lmdb
 }
 #endif
     
-#region DllImport
 public static partial class Lmdb
 {
     private const string MDB_DLL_NAME = "lmdb";
@@ -207,7 +206,7 @@ public static partial class Lmdb
         return mdb_cursor_put(cursor, ref key, ref dataRef, flags);
     }
 
-#if !NET7_0
+#if !NET7_0_OR_GREATER
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_env_create(out nint env);
 
@@ -341,4 +340,3 @@ public static partial class Lmdb
     }
 #endif
 }
-#endregion

--- a/src/LightningDB/Native/MDBEnvInfo.cs
+++ b/src/LightningDB/Native/MDBEnvInfo.cs
@@ -10,22 +10,22 @@ namespace LightningDB.Native
         /// <summary>
         /// Address of map, if fixed
         /// </summary>
-        public IntPtr me_mapaddr;
+        public nint me_mapaddr;
 
         /// <summary>
         /// Size of the data memory map
         /// </summary>
-        public IntPtr me_mapsize;
+        public nint me_mapsize;
 
         /// <summary>
         /// ID of the last used page
         /// </summary>
-        public IntPtr me_last_pgno;
+        public nint me_last_pgno;
 
         /// <summary>
         /// ID of the last committed transaction
         /// </summary>
-        public IntPtr me_last_txnid;
+        public nint me_last_txnid;
 
         /// <summary>
         /// max reader slots in the environment

--- a/src/LightningDB/Native/MDBEnvInfo.cs
+++ b/src/LightningDB/Native/MDBEnvInfo.cs
@@ -1,40 +1,37 @@
-﻿using System;
+﻿namespace LightningDB.Native;
 
-namespace LightningDB.Native
+/// <summary>
+/// Information about the environment. 
+/// </summary>
+public struct MDBEnvInfo
 {
     /// <summary>
-    /// Information about the environment. 
+    /// Address of map, if fixed
     /// </summary>
-    public struct MDBEnvInfo
-    {
-        /// <summary>
-        /// Address of map, if fixed
-        /// </summary>
-        public nint me_mapaddr;
+    public nint me_mapaddr;
 
-        /// <summary>
-        /// Size of the data memory map
-        /// </summary>
-        public nint me_mapsize;
+    /// <summary>
+    /// Size of the data memory map
+    /// </summary>
+    public nint me_mapsize;
 
-        /// <summary>
-        /// ID of the last used page
-        /// </summary>
-        public nint me_last_pgno;
+    /// <summary>
+    /// ID of the last used page
+    /// </summary>
+    public nint me_last_pgno;
 
-        /// <summary>
-        /// ID of the last committed transaction
-        /// </summary>
-        public nint me_last_txnid;
+    /// <summary>
+    /// ID of the last committed transaction
+    /// </summary>
+    public nint me_last_txnid;
 
-        /// <summary>
-        /// max reader slots in the environment
-        /// </summary>
-        public uint me_maxreaders;
+    /// <summary>
+    /// max reader slots in the environment
+    /// </summary>
+    public uint me_maxreaders;
 
-        /// <summary>
-        /// max reader slots used in the environment
-        /// </summary>
-        public uint me_numreaders;
-    }
+    /// <summary>
+    /// max reader slots used in the environment
+    /// </summary>
+    public uint me_numreaders;
 }

--- a/src/LightningDB/Native/MDBStat.cs
+++ b/src/LightningDB/Native/MDBStat.cs
@@ -20,21 +20,21 @@ namespace LightningDB.Native
         /// <summary>
         /// Number of internal (non-leaf) pages
         /// </summary>
-        public IntPtr ms_branch_pages;
+        public nint ms_branch_pages;
 
         /// <summary>
         /// Number of leaf pages
         /// </summary>
-        public IntPtr ms_leaf_pages;
+        public nint ms_leaf_pages;
 
         /// <summary>
         /// Number of overflow pages
         /// </summary>
-        public IntPtr ms_overflow_pages;
+        public nint ms_overflow_pages;
 
         /// <summary>
         /// Number of data items
         /// </summary>
-        public IntPtr ms_entries;
+        public nint ms_entries;
     }
 }

--- a/src/LightningDB/Native/MDBStat.cs
+++ b/src/LightningDB/Native/MDBStat.cs
@@ -1,40 +1,37 @@
-﻿using System;
+﻿namespace LightningDB.Native;
 
-namespace LightningDB.Native
+/// <summary>
+/// Statistics for a database in the environment. 
+/// </summary>
+public struct MDBStat
 {
     /// <summary>
-    /// Statistics for a database in the environment. 
+    /// Size of a database page. This is currently the same for all databases.
     /// </summary>
-    public struct MDBStat
-    {
-        /// <summary>
-        /// Size of a database page. This is currently the same for all databases.
-        /// </summary>
-        public uint ms_psize;
+    public uint ms_psize;
 
-        /// <summary>
-        /// Depth (height) of the B-tree
-        /// </summary>
-        public uint ms_depth;
+    /// <summary>
+    /// Depth (height) of the B-tree
+    /// </summary>
+    public uint ms_depth;
 
-        /// <summary>
-        /// Number of internal (non-leaf) pages
-        /// </summary>
-        public nint ms_branch_pages;
+    /// <summary>
+    /// Number of internal (non-leaf) pages
+    /// </summary>
+    public nint ms_branch_pages;
 
-        /// <summary>
-        /// Number of leaf pages
-        /// </summary>
-        public nint ms_leaf_pages;
+    /// <summary>
+    /// Number of leaf pages
+    /// </summary>
+    public nint ms_leaf_pages;
 
-        /// <summary>
-        /// Number of overflow pages
-        /// </summary>
-        public nint ms_overflow_pages;
+    /// <summary>
+    /// Number of overflow pages
+    /// </summary>
+    public nint ms_overflow_pages;
 
-        /// <summary>
-        /// Number of data items
-        /// </summary>
-        public nint ms_entries;
-    }
+    /// <summary>
+    /// Number of data items
+    /// </summary>
+    public nint ms_entries;
 }

--- a/src/LightningDB/PutOptions.cs
+++ b/src/LightningDB/PutOptions.cs
@@ -1,43 +1,42 @@
 ﻿using System;
 
-namespace LightningDB
+namespace LightningDB;
+
+/// <summary>
+/// Special options for put operation.
+/// </summary>
+[Flags]
+public enum PutOptions
 {
     /// <summary>
-    /// Special options for put operation.
+    /// No special behavior.
     /// </summary>
-    [Flags]
-    public enum PutOptions
-    {
-        /// <summary>
-        /// No special behavior.
-        /// </summary>
-        None = 0,
+    None = 0,
 
-        /// <summary>
-        /// Only for MDB_DUPSORT
-        /// For put: don't write if the key and data pair already exist.
-        /// For mdb_cursor_del: remove all duplicate data items.
-        /// </summary>
-        NoDuplicateData = 0x20,
+    /// <summary>
+    /// Only for MDB_DUPSORT
+    /// For put: don't write if the key and data pair already exist.
+    /// For mdb_cursor_del: remove all duplicate data items.
+    /// </summary>
+    NoDuplicateData = 0x20,
 
-        /// <summary>
-        /// For put: Don't write if the key already exists.
-        /// </summary>
-        NoOverwrite = 0x10,
+    /// <summary>
+    /// For put: Don't write if the key already exists.
+    /// </summary>
+    NoOverwrite = 0x10,
 
-        /// <summary>
-        /// For put: Just reserve space for data, don't copy it. Return a pointer to the reserved space.
-        /// </summary>
-        ReserveSpace = 0x10000,
+    /// <summary>
+    /// For put: Just reserve space for data, don't copy it. Return a pointer to the reserved space.
+    /// </summary>
+    ReserveSpace = 0x10000,
 
-        /// <summary>
-        /// Data is being appended, don't split full pages.
-        /// </summary>
-        AppendData = 0x20000,
+    /// <summary>
+    /// Data is being appended, don't split full pages.
+    /// </summary>
+    AppendData = 0x20000,
 
-        /// <summary>
-        /// Duplicate data is being appended, don't split full pages.
-        /// </summary>
-        AppendDuplicateData = 0x40000
-    }
+    /// <summary>
+    /// Duplicate data is being appended, don't split full pages.
+    /// </summary>
+    AppendDuplicateData = 0x40000
 }

--- a/src/LightningDB/Stats.cs
+++ b/src/LightningDB/Stats.cs
@@ -1,38 +1,37 @@
-﻿namespace LightningDB
+﻿namespace LightningDB;
+
+/// <summary>
+/// Statistics for a database in the environment. 
+/// </summary>
+public class Stats
 {
     /// <summary>
-    /// Statistics for a database in the environment. 
+    /// Size of a database page. This is currently the same for all databases. 
     /// </summary>
-    public class Stats
-    {
-        /// <summary>
-        /// Size of a database page. This is currently the same for all databases. 
-        /// </summary>
-        public long PageSize { get; set; }
+    public long PageSize { get; set; }
 
-        /// <summary>
-        /// Depth (height) of the B-tree 
-        /// </summary>
-        public long BTreeDepth { get; set; }
+    /// <summary>
+    /// Depth (height) of the B-tree 
+    /// </summary>
+    public long BTreeDepth { get; set; }
 
-        /// <summary>
-        /// Number of internal (non-leaf) pages 
-        /// </summary>
-        public long BranchPages { get; set; }
+    /// <summary>
+    /// Number of internal (non-leaf) pages 
+    /// </summary>
+    public long BranchPages { get; set; }
 
-        /// <summary>
-        /// Number of leaf pages 
-        /// </summary>
-        public long LeafPages { get; set; }
+    /// <summary>
+    /// Number of leaf pages 
+    /// </summary>
+    public long LeafPages { get; set; }
 
-        /// <summary>
-        /// Number of overflow pages 
-        /// </summary>
-        public long OverflowPages { get; set; }
+    /// <summary>
+    /// Number of overflow pages 
+    /// </summary>
+    public long OverflowPages { get; set; }
 
-        /// <summary>
-        /// Number of data items 
-        /// </summary>
-        public long Entries { get; set; }
-    }
+    /// <summary>
+    /// Number of data items 
+    /// </summary>
+    public long Entries { get; set; }
 }

--- a/src/LightningDB/TransactionBeginFlags.cs
+++ b/src/LightningDB/TransactionBeginFlags.cs
@@ -1,41 +1,40 @@
-﻿namespace LightningDB
+﻿namespace LightningDB;
+
+/// <summary>
+/// Transaction open mode
+/// </summary>
+public enum TransactionBeginFlags
 {
     /// <summary>
-    /// Transaction open mode
+    /// Normal mode
     /// </summary>
-    public enum TransactionBeginFlags
-    {
-        /// <summary>
-        /// Normal mode
-        /// </summary>
-        None = 0,
+    None = 0,
 
-        /// <summary>
-        /// MDB_NOSYNC. Don't flush system buffers to disk when committing a transaction.
-        /// This optimization means a system crash can corrupt the database or lose the last transactions if buffers are not yet flushed to disk.
-        /// The risk is governed by how often the system flushes dirty buffers to disk and how often mdb_env_sync() is called.
-        /// However, if the filesystem preserves write order and the MDB_WRITEMAP flag is not used, transactions exhibit ACI (atomicity, consistency, isolation) properties and only lose D (durability).
-        /// I.e. database integrity is maintained, but a system crash may undo the final transactions.
-        /// Note that (MDB_NOSYNC | MDB_WRITEMAP) leaves the system with no hint for when to write transactions to disk, unless mdb_env_sync() is called.
-        /// (MDB_MAPASYNC | MDB_WRITEMAP) may be preferable.
-        /// This flag may be changed at any time using mdb_env_set_flags().
-        /// </summary>
-        NoSync = 0x10000,
+    /// <summary>
+    /// MDB_NOSYNC. Don't flush system buffers to disk when committing a transaction.
+    /// This optimization means a system crash can corrupt the database or lose the last transactions if buffers are not yet flushed to disk.
+    /// The risk is governed by how often the system flushes dirty buffers to disk and how often mdb_env_sync() is called.
+    /// However, if the filesystem preserves write order and the MDB_WRITEMAP flag is not used, transactions exhibit ACI (atomicity, consistency, isolation) properties and only lose D (durability).
+    /// I.e. database integrity is maintained, but a system crash may undo the final transactions.
+    /// Note that (MDB_NOSYNC | MDB_WRITEMAP) leaves the system with no hint for when to write transactions to disk, unless mdb_env_sync() is called.
+    /// (MDB_MAPASYNC | MDB_WRITEMAP) may be preferable.
+    /// This flag may be changed at any time using mdb_env_set_flags().
+    /// </summary>
+    NoSync = 0x10000,
 
-        /// <summary>
-        /// MDB_RDONLY. Open the environment in read-only mode. 
-        /// No write operations will be allowed. 
-        /// MDB will still modify the lock file - except on read-only filesystems, where MDB does not use locks.
-        /// </summary>
-        ReadOnly = 0x20000,
+    /// <summary>
+    /// MDB_RDONLY. Open the environment in read-only mode. 
+    /// No write operations will be allowed. 
+    /// MDB will still modify the lock file - except on read-only filesystems, where MDB does not use locks.
+    /// </summary>
+    ReadOnly = 0x20000,
 
-        /// <summary>
-        /// MDB_NOMETASYNC. Flush system buffers to disk only once per transaction, omit the metadata flush.
-        /// Defer that until the system flushes files to disk, or next non-MDB_RDONLY commit or mdb_env_sync().
-        /// This optimization maintains database integrity, but a system crash may undo the last committed transaction.
-        /// I.e. it preserves the ACI (atomicity, consistency, isolation) but not D (durability) database property.
-        /// This flag may be changed at any time using mdb_env_set_flags().
-        /// </summary>
-        NoMetaSync = 0x40000,
-    }
+    /// <summary>
+    /// MDB_NOMETASYNC. Flush system buffers to disk only once per transaction, omit the metadata flush.
+    /// Defer that until the system flushes files to disk, or next non-MDB_RDONLY commit or mdb_env_sync().
+    /// This optimization maintains database integrity, but a system crash may undo the last committed transaction.
+    /// I.e. it preserves the ACI (atomicity, consistency, isolation) but not D (durability) database property.
+    /// This flag may be changed at any time using mdb_env_set_flags().
+    /// </summary>
+    NoMetaSync = 0x40000
 }

--- a/src/LightningDB/UnixAccessMode.cs
+++ b/src/LightningDB/UnixAccessMode.cs
@@ -1,61 +1,60 @@
 ﻿using System;
 
-namespace LightningDB
+namespace LightningDB;
+
+/// <summary>
+/// Unix file access privileges
+/// </summary>
+[Flags]
+public enum UnixAccessMode : uint
 {
     /// <summary>
-    /// Unix file access privileges
+    /// S_IRUSR
     /// </summary>
-    [Flags]
-    public enum UnixAccessMode : uint
-    {
-        /// <summary>
-        /// S_IRUSR
-        /// </summary>
-        OwnerRead = 0x0100,
+    OwnerRead = 0x0100,
 
-        /// <summary>
-        /// S_IWUSR
-        /// </summary>
-        OwnerWrite = 0x0080, 
+    /// <summary>
+    /// S_IWUSR
+    /// </summary>
+    OwnerWrite = 0x0080, 
 
-        /// <summary>
-        /// S_IXUSR
-        /// </summary>
-        OwnerExec = 0x0040, 
+    /// <summary>
+    /// S_IXUSR
+    /// </summary>
+    OwnerExec = 0x0040, 
 
-        /// <summary>
-        /// S_IRGRP
-        /// </summary>
-        GroupRead = 0x0020,
+    /// <summary>
+    /// S_IRGRP
+    /// </summary>
+    GroupRead = 0x0020,
 
-        /// <summary>
-        /// S_IWGRP
-        /// </summary>
-        GroupWrite = 0x0010,
+    /// <summary>
+    /// S_IWGRP
+    /// </summary>
+    GroupWrite = 0x0010,
 
-        /// <summary>
-        /// S_IXGRP
-        /// </summary>
-        GroupExec = 0x0008, 
+    /// <summary>
+    /// S_IXGRP
+    /// </summary>
+    GroupExec = 0x0008, 
 
-        /// <summary>
-        /// S_IROTH
-        /// </summary>
-        OtherRead = 0x0004, 
+    /// <summary>
+    /// S_IROTH
+    /// </summary>
+    OtherRead = 0x0004, 
 
-        /// <summary>
-        /// S_IWOTH
-        /// </summary>
-        OtherWrite = 0x0002, 
+    /// <summary>
+    /// S_IWOTH
+    /// </summary>
+    OtherWrite = 0x0002, 
 
-        /// <summary>
-        /// S_IXOTH
-        /// </summary>
-        OtherExec = 0x0001,
+    /// <summary>
+    /// S_IXOTH
+    /// </summary>
+    OtherExec = 0x0001,
 
-        /// <summary>
-        /// Owner, Group, Other Read/Write
-        /// </summary>
-        Default = OwnerRead | OwnerWrite | GroupRead | GroupWrite | OtherRead | OtherWrite
-    }
+    /// <summary>
+    /// Owner, Group, Other Read/Write
+    /// </summary>
+    Default = OwnerRead | OwnerWrite | GroupRead | GroupWrite | OtherRead | OtherWrite
 }

--- a/src/SecondProcess/Program.cs
+++ b/src/SecondProcess/Program.cs
@@ -3,25 +3,24 @@ using System.Linq;
 using System.Text;
 using LightningDB;
 
-namespace SecondProcess
-{
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            var name = args.First();
-            using var env = new LightningEnvironment(name);
-            env.Open(EnvironmentOpenFlags.ReadOnly);
-            byte[] results;
-            using (var tx = env.BeginTransaction(TransactionBeginFlags.ReadOnly))
-            {
-                using var db = tx.OpenDatabase();
-                var result = tx.Get(db, Encoding.UTF8.GetBytes("hello"));
-                results = result.value.CopyToNewArray();
-                tx.Commit();
-            }
+namespace SecondProcess;
 
-            Console.WriteLine(Encoding.UTF8.GetString(results));
+class Program
+{
+    static void Main(string[] args)
+    {
+        var name = args.First();
+        using var env = new LightningEnvironment(name);
+        env.Open(EnvironmentOpenFlags.ReadOnly);
+        byte[] results;
+        using (var tx = env.BeginTransaction(TransactionBeginFlags.ReadOnly))
+        {
+            using var db = tx.OpenDatabase();
+            var result = tx.Get(db, "hello"u8.ToArray());
+            results = result.value.CopyToNewArray();
+            tx.Commit();
         }
+
+        Console.WriteLine(Encoding.UTF8.GetString(results));
     }
 }

--- a/src/SecondProcess/SecondProcess.csproj
+++ b/src/SecondProcess/SecondProcess.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+        <LangVersion>11</LangVersion>
         <LightningDBTargetRuntimeRelativePath>.\</LightningDBTargetRuntimeRelativePath>
     </PropertyGroup>
 


### PR DESCRIPTION
Summary of PR:
* Added usage of LibraryImport when targeting net7.0
* Marshall environment name string as UTF-8 with the LibraryImport options
* Using nint throughout over previous IntPtr
* File-scoped namespaces
* Fixed test being excluded on Linux for using environment from multi-process
* Corrected numerous inconsistencies and analysis warnings where it made sense

Are there other language features this library would benefit from that I missed?

I'm going to run the benchmarks out of curiosity to see the differences between net6.0, net7.0 (master), and net7.0 (net7-csharp-improvements)
