### PR TITLE
Hide native dlls in Visual Studio

### DIFF
--- a/src/LightningDB/LightningDB.targets
+++ b/src/LightningDB/LightningDB.targets
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <LightningDBTargetRuntimeRelativePath Condition=" '$(LightningDBTargetRuntimeRelativePath)' == '' ">\..\</LightningDBTargetRuntimeRelativePath>
   </PropertyGroup>
+	<Target Name="LightningDBIncludeNativeDll" AfterTargets="BeforeResolveReferences">
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)$(LightningDBTargetRuntimeRelativePath)runtimes\win-x86\native\*" 
           CopyToOutputDirectory="PreserveNewest" 
@@ -27,4 +28,5 @@
           CopyToOutputDirectory="PreserveNewest"
           Condition="'$([MSBuild]::IsOsPlatform(Linux))' And '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)'=='X64'" />
   </ItemGroup>
+	</Target>
 </Project>


### PR DESCRIPTION
In version 0.15.0, including the package results in the native dlls being displayed in visual studio due to the target file directly including the Dlls at design time

![image](https://github.com/CoreyKaylor/Lightning.NET/assets/37318755/ac961587-d15f-409b-9a6c-3e2488237ffc)

This is a little fix to "delay" the inclusion of those files at actual build time so that the dlls do not appear in the IDE.