### PR TITLE
Having LightningEnvironment.CopyTo return an MDBResultCode

### DIFF
--- a/src/LightningDB.Tests/EnvironmentTests.cs
+++ b/src/LightningDB.Tests/EnvironmentTests.cs
@@ -137,10 +137,23 @@ public class EnvironmentTests : IDisposable
         _env = new LightningEnvironment(_path);
         _env.Open(); 
 
-        _env.CopyTo(_pathCopy, compact);
+        _env.CopyTo(_pathCopy, compact).ThrowOnError();
 
         if (Directory.GetFiles(_pathCopy).Length == 0)
             Assert.True(false, "Copied files doesn't exist");
+    }
+
+    [Fact]
+    public void EnvironmentShouldFailCopyIfPathIsFile()
+    {
+        _env = new LightningEnvironment(_path);
+        _env.Open();
+
+        string filePath = Path.Combine(_pathCopy, "test.txt");
+        File.WriteAllBytes(filePath, Array.Empty<byte>());
+        
+        MDBResultCode result = _env.CopyTo(filePath);
+        Assert.NotEqual(MDBResultCode.Success, result);
     }
 
     [Fact]

--- a/src/LightningDB/LightningEnvironment.cs
+++ b/src/LightningDB/LightningEnvironment.cs
@@ -245,7 +245,7 @@ public sealed class LightningEnvironment : IDisposable
     /// </summary>
     /// <param name="path">The directory in which the copy will reside. This directory must already exist and be writable but must otherwise be empty.</param>
     /// <param name="compact">Omit empty pages when copying.</param>
-    public void CopyTo(string path, bool compact = false)
+    public MDBResultCode CopyTo(string path, bool compact = false)
     {
         EnsureOpened();
 
@@ -253,7 +253,7 @@ public sealed class LightningEnvironment : IDisposable
             ? EnvironmentCopyFlags.Compact 
             : EnvironmentCopyFlags.None;
             
-        mdb_env_copy2(_handle, path, flags);
+        return mdb_env_copy2(_handle, path, flags);
     }
 
     /// <summary>


### PR DESCRIPTION
Should enable detection of failed copies.

Added test to verify this behavior.