### PR TITLE
Expose mdb_cursor_count()

### DIFF
--- a/src/LightningDB.Tests/CursorTests.cs
+++ b/src/LightningDB.Tests/CursorTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Xunit;
 using static System.Text.Encoding;
@@ -396,5 +396,20 @@ public class CursorTests : IDisposable
             ReproduceCoreIteration(_env, db);
         }
         Assert.True(true, "Code would be unreachable otherwise.");
+    }
+    
+    [Fact]
+    public void CountCursor()
+    {
+        _env.RunCursorScenario((_, _, c) =>
+        {
+            var key = "TestKey"u8.ToArray();
+            var keys = PopulateMultipleCursorValues(c);
+
+            c.SetRange(key);
+            c.Count(out var amount);
+            
+            Assert.Equal(5, amount);
+        }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create);
     }
 }

--- a/src/LightningDB/LightningCursor.cs
+++ b/src/LightningDB/LightningCursor.cs
@@ -497,6 +497,18 @@ public class LightningCursor : IDisposable
 
         return mdb_cursor_renew(txn.Handle(), _handle);
     }
+    
+    /// <summary>
+    /// Return count of duplicates for current key.
+    /// 
+    /// This call is only valid on databases that support sorted duplicate data items DatabaseOpenFlags.DuplicatesFixed. 
+    /// </summary>
+    /// <param name="value">Output parameter where the duplicate count will be stored.</param>
+    /// <returns>Returns <see cref="MDBResultCode"/></returns>
+    public MDBResultCode Count(out int value)
+    {
+        return mdb_cursor_count(_handle, out value);
+    }
 
     /// <summary>
     /// Closes the cursor and deallocates all resources associated with it.

--- a/src/LightningDB/Native/Lmdb.cs
+++ b/src/LightningDB/Native/Lmdb.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -103,6 +103,9 @@ public static partial class Lmdb
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
     public static partial MDBResultCode mdb_get(nint txn, uint dbi, ref MDBValue key, out MDBValue data);
+        
+    [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+    public static extern MDBResultCode mdb_cursor_count(nint cursor, out int countp);
         
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = new []{typeof(CallConvCdecl)})]
@@ -299,6 +302,9 @@ public static partial class Lmdb
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_get(nint txn, uint dbi, ref MDBValue key, out MDBValue data);
+
+        [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern MDBResultCode mdb_cursor_count(nint cursor, out int countp);
 
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_put(nint txn, uint dbi, ref MDBValue key, ref MDBValue data, PutOptions flags);


### PR DESCRIPTION
Add mdb_cursor_count() so the amount of duplicated keys can be obtained without iterating.