### PR TITLE
Accessing database stats with explicit transaction

### DIFF
--- a/src/LightningDB.Tests/DatabaseTests.cs
+++ b/src/LightningDB.Tests/DatabaseTests.cs
@@ -164,4 +164,21 @@ public class DatabaseTests(SharedFileSystem fileSystem) : TestBase(fileSystem)
 
         Assert.Equal(MDBResultCode.NotFound, result.resultCode);
     }
+
+    [Fact]
+    public void DatabaseCanGetStats()
+    {
+        _env.Open();
+        using var txn = _env.BeginTransaction();
+        using var db = txn.OpenDatabase();
+        
+        txn.Put(db, "key", 1.ToString()).ThrowOnError();
+        var stats = db.DatabaseStats;
+        Assert.Equal(1, stats.Entries);
+        Assert.Equal(0, stats.BranchPages);
+        Assert.Equal(1, stats.LeafPages);
+        Assert.Equal(0, stats.OverflowPages);
+        Assert.Equal(_env.EnvironmentStats.PageSize, stats.PageSize);
+        Assert.Equal(1, stats.BTreeDepth);
+    }
 }

--- a/src/LightningDB/LightningDatabase.cs
+++ b/src/LightningDB/LightningDatabase.cs
@@ -48,22 +48,7 @@ public sealed class LightningDatabase : IDisposable
     /// </summary>
     public bool IsOpened { get; private set; }
 
-    public Stats DatabaseStats
-    {
-        get
-        {
-            mdb_stat(_transaction._handle, _handle, out var nativeStat).ThrowOnError();
-            return new Stats
-            {
-                BranchPages = nativeStat.ms_branch_pages,
-                BTreeDepth = nativeStat.ms_depth,
-                Entries = nativeStat.ms_entries,
-                LeafPages = nativeStat.ms_leaf_pages,
-                OverflowPages = nativeStat.ms_overflow_pages,
-                PageSize = nativeStat.ms_psize
-            };
-        }
-    }
+    public Stats DatabaseStats => _transaction.GetStats(this);
 
     /// <summary>
     /// Database name.

--- a/src/LightningDB/LightningTransaction.cs
+++ b/src/LightningDB/LightningTransaction.cs
@@ -312,6 +312,25 @@ public sealed class LightningTransaction : IDisposable
     }
 
     /// <summary>
+    /// Retrieve the statistics for the specified database.
+    /// </summary>
+    /// <param name="db">The database we are interested in.</param>
+    /// <returns>The retrieved statistics.</returns>
+    public Stats GetStats(LightningDatabase db)
+    {
+        mdb_stat(_handle, db._handle, out var stat).ThrowOnError();
+        return new Stats
+        {
+            BranchPages = stat.ms_branch_pages,
+            BTreeDepth = stat.ms_depth,
+            Entries = stat.ms_entries,
+            LeafPages = stat.ms_leaf_pages,
+            OverflowPages = stat.ms_overflow_pages,
+            PageSize = stat.ms_psize
+        };
+    }
+
+    /// <summary>
     /// Environment in which the transaction was opened.
     /// </summary>
     public LightningEnvironment Environment { get; }


### PR DESCRIPTION
Adding method to `LightningTransaction` to load database stats.  This is useful when the database was opened via a committed transaction, and then subsequently re-used by later transactions (since the original transaction is no longer valid).

Also updating `LightningDatabase.DatabaseStats` to call this method with its original transaction to reduce (now) duplicate code.

Added test cases for new method and `LightningDatabase.DatabaseStats`.