### PR TITLE
Add missing native functions to Lmdb imports and add much more test coverage

### DIFF
--- a/src/LightningDB.Tests/CursorTests.cs
+++ b/src/LightningDB.Tests/CursorTests.cs
@@ -33,14 +33,14 @@ public class CursorTests : TestBase
         return values;
     }
 
-    public void CursorShouldBeCreated()
+    public void cursor_should_be_created()
     {
         using var env = CreateEnvironment();
         env.Open();
         env.RunCursorScenario((_, _, c) => c.ShouldNotBeNull());
     }
 
-    public void CursorShouldPutValues()
+    public void cursor_should_put_values()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -52,7 +52,7 @@ public class CursorTests : TestBase
         });
     }
 
-    public void CursorShouldSetSpanKey()
+    public void cursor_should_set_span_key()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -67,7 +67,7 @@ public class CursorTests : TestBase
         });
     }
 
-    public void CursorShouldMoveToLast()
+    public void cursor_should_move_to_last()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -81,7 +81,7 @@ public class CursorTests : TestBase
         });
     }
 
-    public void CursorShouldMoveToFirst()
+    public void cursor_should_move_to_first()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -95,7 +95,7 @@ public class CursorTests : TestBase
         });
     }
 
-    public void ShouldIterateThroughCursor()
+    public void should_iterate_through_cursor()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -113,7 +113,7 @@ public class CursorTests : TestBase
         });
     }
 
-    public void CursorShouldDeleteElements()
+    public void cursor_should_delete_elements()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -131,7 +131,7 @@ public class CursorTests : TestBase
         });
     }
 
-    public void ShouldPutMultiple()
+    public void should_put_multiple()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -139,7 +139,7 @@ public class CursorTests : TestBase
             DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create);
     }
 
-    public void ShouldGetMultiple()
+    public void should_get_multiple()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -155,7 +155,7 @@ public class CursorTests : TestBase
         }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create);
     }
 
-    public void ShouldGetNextMultiple()
+    public void should_get_next_multiple()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -170,7 +170,7 @@ public class CursorTests : TestBase
         }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create);
     }
 
-    public void ShouldAdvanceKeyToClosestWhenKeyNotFound()
+    public void should_advance_key_to_closest_when_key_not_found()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -184,7 +184,7 @@ public class CursorTests : TestBase
         });
     }
 
-    public void ShouldSetKeyAndGet()
+    public void should_set_key_and_get()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -197,7 +197,7 @@ public class CursorTests : TestBase
         }); 
     }
         
-    public void ShouldSetKeyAndGetWithSpan()
+    public void should_set_key_and_get_with_span()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -210,7 +210,7 @@ public class CursorTests : TestBase
         }); 
     }
         
-    public void ShouldGetBoth()
+    public void should_get_both()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -222,7 +222,7 @@ public class CursorTests : TestBase
         }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create); 
     }
         
-    public void ShouldGetBothWithSpan()
+    public void should_get_both_with_span()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -235,7 +235,7 @@ public class CursorTests : TestBase
         }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create); 
     }
         
-    public void ShouldMoveToPrevious()
+    public void should_move_to_previous()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -249,7 +249,7 @@ public class CursorTests : TestBase
         }); 
     }
         
-    public void ShouldSetRangeWithSpan()
+    public void should_set_range_with_span()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -264,7 +264,7 @@ public class CursorTests : TestBase
         }); 
     }
         
-    public void ShouldGetBothRange()
+    public void should_get_both_range()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -279,7 +279,7 @@ public class CursorTests : TestBase
         }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create); 
     }
         
-    public void ShouldGetBothRangeWithSpan()
+    public void should_get_both_range_with_span()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -294,7 +294,7 @@ public class CursorTests : TestBase
         }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create); 
     }
         
-    public void ShouldMoveToFirstDuplicate()
+    public void should_move_to_first_duplicate()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -310,7 +310,7 @@ public class CursorTests : TestBase
         }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create); 
     }
         
-    public void ShouldMoveToLastDuplicate()
+    public void should_move_to_last_duplicate()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -325,7 +325,7 @@ public class CursorTests : TestBase
         }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create); 
     }
     
-    public void AllValuesForShouldOnlyReturnMatchingKeyValues()
+    public void all_values_for_should_only_return_matching_key_values()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -355,7 +355,7 @@ public class CursorTests : TestBase
         }, DatabaseOpenFlags.DuplicatesSort | DatabaseOpenFlags.Create);
     }
         
-    public void ShouldMoveToNextNoDuplicate()
+    public void should_move_to_next_no_duplicate()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -369,7 +369,7 @@ public class CursorTests : TestBase
     }
     
     
-    public void ShouldRetrieveAllValuesForKey()
+    public void should_retrieve_all_values_for_key()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -392,7 +392,7 @@ public class CursorTests : TestBase
         }, DatabaseOpenFlags.DuplicatesSort | DatabaseOpenFlags.Create);
     }
     
-    public void ShouldRenewSameTransaction()
+    public void should_renew_same_transaction()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -403,7 +403,7 @@ public class CursorTests : TestBase
         }, transactionFlags: TransactionBeginFlags.ReadOnly); 
     }
 
-    public void ShouldDeleteDuplicates()
+    public void should_delete_duplicates()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -418,7 +418,7 @@ public class CursorTests : TestBase
         }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create);  
     }
 
-    public void CanPutBatchesViaCursorIssue155()
+    public void can_put_batches_via_cursor_issue_155()
     {
         static LightningDatabase OpenDatabase(LightningEnvironment environment)
         {
@@ -456,7 +456,7 @@ public class CursorTests : TestBase
         true.ShouldBeTrue("Code would be unreachable otherwise.");
     }
     
-    public void CountCursor()
+    public void count_cursor()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -469,6 +469,288 @@ public class CursorTests : TestBase
             c.Count(out var amount);
             
             amount.ShouldBe(5);
+        }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create);
+    }
+    
+    public void should_move_to_previous_duplicate()
+    {
+        using var env = CreateEnvironment();
+        env.Open();
+        env.RunCursorScenario((_, _, c) =>
+        {
+            var key = "TestKey"u8.ToArray();
+            var values = PopulateMultipleCursorValues(c);
+            
+            // Move to last duplicate
+            c.Set(key);
+            c.LastDuplicate();
+            
+            // Now move to previous duplicate from the last one
+            var result = c.PreviousDuplicate();
+            result.resultCode.ShouldBe(MDBResultCode.Success);
+            
+            // Verify we're at the second-to-last value
+            result.value.CopyToNewArray().ShouldBe(values[3]); // Previous of the last (values[4])
+        }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create);
+    }
+    
+    public void should_test_previous_operation()
+    {
+        using var env = CreateEnvironment();
+        env.Open();
+        env.RunCursorScenario((_, _, c) =>
+        {
+            // Create key-value pairs
+            var keys = PopulateCursorValues(c);
+            
+            // Position at the last item
+            var result = c.Last();
+            result.resultCode.ShouldBe(MDBResultCode.Success);
+            
+            // Now test Previous which should move to the previous item
+            result = c.Previous();
+            result.resultCode.ShouldBe(MDBResultCode.Success);
+            
+            // Verify we're at the second-to-last key
+            var current = c.GetCurrent();
+            current.key.CopyToNewArray().ShouldBe(keys[keys.Length - 2]);
+        });
+    }
+    
+    public void should_attempt_previous_no_duplicate_operation()
+    {
+        using var env = CreateEnvironment();
+        env.Open();
+        env.RunCursorScenario((_, _, c) =>
+        {
+            // Create key-value pairs
+            var keys = PopulateCursorValues(c);
+            
+            // Position at a key
+            c.Set(keys[2]);
+            
+            // Call PreviousNoDuplicate - we just check it doesn't throw,
+            // we don't validate the exact behavior since it might not be fully implemented
+            var (result, _, _) = c.PreviousNoDuplicate();
+            result.ShouldBe(MDBResultCode.Success);
+        });
+    }
+    
+    public void should_renew_with_transaction()
+    {
+        using var env = CreateEnvironment();
+        env.Open();
+        
+        // Create read-only transaction and cursor
+        using var tx1 = env.BeginTransaction(TransactionBeginFlags.ReadOnly);
+        using var db = tx1.OpenDatabase();
+        using var cursor = tx1.CreateCursor(db);
+        
+        // Reset the transaction
+        tx1.Reset();
+        
+        // Create new transaction
+        using var tx2 = env.BeginTransaction(TransactionBeginFlags.ReadOnly);
+        
+        // Renew cursor with new transaction
+        var result = cursor.Renew(tx2);
+        result.ShouldBe(MDBResultCode.Success);
+        
+        // Verify cursor is usable with new transaction
+        var (resultCode, _, _) = cursor.First();
+        resultCode.ShouldBe(MDBResultCode.NotFound);
+    }
+    
+    public void should_put_with_span_parameters()
+    {
+        using var env = CreateEnvironment();
+        env.Open();
+        env.RunCursorScenario((_, _, c) =>
+        {
+            var keySpan = "SpanKey"u8.ToArray().AsSpan();
+            var valueSpan = "SpanValue"u8.ToArray().AsSpan();
+            
+            // Test the Put method with ReadOnlySpan<byte> parameters
+            var result = c.Put(keySpan, valueSpan, CursorPutOptions.None);
+            result.ShouldBe(MDBResultCode.Success);
+            
+            // Verify data was stored correctly
+            c.Set(keySpan);
+            var current = c.GetCurrent();
+            UTF8.GetString(current.value.CopyToNewArray()).ShouldBe("SpanValue");
+        });
+    }
+    
+    public void should_use_current_put_option()
+    {
+        using var env = CreateEnvironment();
+        env.Open();
+        env.RunCursorScenario((_, _, c) =>
+        {
+            // First create a key-value pair
+            var key = "TestKey"u8.ToArray();
+            var initialValue = "InitialValue"u8.ToArray();
+            var updatedValue = "UpdatedValue"u8.ToArray();
+            
+            // Put initial key/value
+            var result = c.Put(key, initialValue, CursorPutOptions.None);
+            result.ShouldBe(MDBResultCode.Success);
+            
+            // Position cursor at the key we just inserted
+            c.Set(key);
+            
+            // Now use Current option to update the value without specifying key
+            // The key parameter is ignored with Current option
+            result = c.Put("ignored"u8.ToArray(), updatedValue, CursorPutOptions.Current);
+            result.ShouldBe(MDBResultCode.Success);
+            
+            // Verify the value was updated
+            c.Set(key);
+            var current = c.GetCurrent();
+            current.value.CopyToNewArray().ShouldBe(updatedValue);
+        });
+    }
+
+    public void should_not_overwrite_with_no_overwrite_option()
+    {
+        using var env = CreateEnvironment();
+        env.Open();
+        env.RunCursorScenario((_, _, c) =>
+        {
+            // First create a key-value pair
+            var key = "TestKey"u8.ToArray();
+            var initialValue = "InitialValue"u8.ToArray();
+            var newValue = "NewValue"u8.ToArray();
+            
+            // Put initial key/value
+            var result = c.Put(key, initialValue, CursorPutOptions.None);
+            result.ShouldBe(MDBResultCode.Success);
+            
+            // Try to put same key with NoOverwrite option
+            result = c.Put(key, newValue, CursorPutOptions.NoOverwrite);
+            result.ShouldBe(MDBResultCode.KeyExist);
+            
+            // Verify original value is unchanged
+            c.Set(key);
+            var current = c.GetCurrent();
+            current.value.CopyToNewArray().ShouldBe(initialValue);
+        });
+    }
+
+    public void should_test_no_duplicate_data_option()
+    {
+        using var env = CreateEnvironment();
+        env.Open();
+        env.RunCursorScenario((_, _, c) =>
+        {
+            // Set up a key with multiple values
+            var key = "TestKey"u8.ToArray();
+            var value1 = "Value1"u8.ToArray();
+            var value2 = "Value2"u8.ToArray();
+            
+            // Add first value
+            var result = c.Put(key, value1, CursorPutOptions.None);
+            result.ShouldBe(MDBResultCode.Success);
+            
+            // Add second value
+            result = c.Put(key, value2, CursorPutOptions.None);
+            result.ShouldBe(MDBResultCode.Success);
+            
+            // Try to add the first value again with NoDuplicateData option
+            result = c.Put(key, value1, CursorPutOptions.NoDuplicateData);
+            result.ShouldBe(MDBResultCode.KeyExist);
+            
+            // Add a new value with NoDuplicateData option should succeed
+            var value3 = "Value3"u8.ToArray();
+            result = c.Put(key, value3, CursorPutOptions.NoDuplicateData);
+            result.ShouldBe(MDBResultCode.Success);
+        }, DatabaseOpenFlags.DuplicatesSort | DatabaseOpenFlags.Create);
+    }
+
+    public void should_append_data_with_append_option()
+    {
+        using var env = CreateEnvironment();
+        env.Open();
+        env.RunCursorScenario((_, _, c) =>
+        {
+            // Create sorted keys
+            var keys = Enumerable.Range(1, 5)
+                .Select(i => UTF8.GetBytes($"key{i:D5}"))
+                .ToArray();
+            
+            // Insert keys in order with AppendData option
+            foreach (var key in keys)
+            {
+                var result = c.Put(key, key, CursorPutOptions.AppendData);
+                result.ShouldBe(MDBResultCode.Success);
+            }
+            
+            // Verify all keys were inserted correctly
+            c.First();
+            for (int i = 0; i < keys.Length; i++)
+            {
+                var current = c.GetCurrent();
+                current.key.CopyToNewArray().ShouldBe(keys[i]);
+                current.value.CopyToNewArray().ShouldBe(keys[i]);
+                
+                if (i < keys.Length - 1)
+                    c.Next();
+            }
+        });
+    }
+
+    public void should_append_duplicate_data_with_append_duplicate_option()
+    {
+        using var env = CreateEnvironment();
+        env.Open();
+        env.RunCursorScenario((_, _, c) =>
+        {
+            var key = "TestKey"u8.ToArray();
+            var values = Enumerable.Range(1, 5)
+                .Select(i => UTF8.GetBytes($"value{i:D5}"))
+                .ToArray();
+            
+            // Put the key once
+            var result = c.Put(key, values[0], CursorPutOptions.None);
+            result.ShouldBe(MDBResultCode.Success);
+            
+            // Now append duplicate values in order
+            for (int i = 1; i < values.Length; i++)
+            {
+                result = c.Put(key, values[i], CursorPutOptions.AppendDuplicateData);
+                result.ShouldBe(MDBResultCode.Success);
+            }
+            
+            // Verify all values were inserted for the key
+            c.Set(key);
+            var allValues = c.AllValuesFor(key).Select(v => v.CopyToNewArray()).ToArray();
+            allValues.Length.ShouldBe(values.Length);
+        }, DatabaseOpenFlags.DuplicatesSort | DatabaseOpenFlags.Create);
+    }
+
+    public void should_test_multiple_data_option()
+    {
+        using var env = CreateEnvironment();
+        env.Open();
+        env.RunCursorScenario((_, _, c) =>
+        {
+            var key = "TestKey"u8.ToArray();
+            var values = Enumerable.Range(1, 5)
+                .Select(i => BitConverter.GetBytes(i)) // Use fixed-size values
+                .ToArray();
+            
+            // Put multiple values in one operation
+            var result = c.Put(key, values);
+            result.ShouldBe(MDBResultCode.Success);
+            
+            // Verify the values were stored
+            c.Set(key);
+            var (resultCode, _, value) = c.GetMultiple();
+            resultCode.ShouldBe(MDBResultCode.Success);
+            
+            // Verify we can split the data into individual values
+            var data = value.CopyToNewArray();
+            data.Length.ShouldBe(values.Sum(v => v.Length));
         }, DatabaseOpenFlags.DuplicatesFixed | DatabaseOpenFlags.Create);
     }
 }

--- a/src/LightningDB.Tests/DatabaseIOTests.cs
+++ b/src/LightningDB.Tests/DatabaseIOTests.cs
@@ -4,7 +4,7 @@ namespace LightningDB.Tests;
 
 public class DatabaseIOTests : TestBase
 {
-    public void DatabasePutShouldNotThrowExceptions()
+    public void database_put_should_not_throw_exceptions()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -17,7 +17,7 @@ public class DatabaseIOTests : TestBase
         });
     }
 
-    public void DatabaseGetShouldNotThrowExceptions()
+    public void database_get_should_not_throw_exceptions()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -27,7 +27,7 @@ public class DatabaseIOTests : TestBase
         });
     }
 
-    public void DatabaseInsertedValueShouldBeRetrievedThen()
+    public void database_inserted_value_should_be_retrieved_then()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -43,7 +43,7 @@ public class DatabaseIOTests : TestBase
         });
     }
 
-    public void DatabaseDeleteShouldRemoveItem()
+    public void database_delete_should_remove_item()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -59,7 +59,7 @@ public class DatabaseIOTests : TestBase
         });
     }
 
-    public void DatabaseDeleteShouldRemoveAllDuplicateDataItems()
+    public void database_delete_should_remove_all_duplicate_data_items()
     {
         using var env = CreateEnvironment(TempPath(), new EnvironmentConfiguration { MapSize = 1024 * 1024 });
         env.Open();
@@ -77,7 +77,7 @@ public class DatabaseIOTests : TestBase
         }, DatabaseOpenFlags.DuplicatesSort);
     }
 
-    public void ContainsKeyShouldReturnTrueIfKeyExists()
+    public void contains_key_should_return_true_if_key_exists()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -94,7 +94,7 @@ public class DatabaseIOTests : TestBase
         });
     }
 
-    public void ContainsKeyShouldReturnFalseIfKeyNotExists()
+    public void contains_key_should_return_false_if_key_not_exists()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -107,7 +107,7 @@ public class DatabaseIOTests : TestBase
         });
     }
 
-    public void TryGetShouldReturnValueIfKeyExists()
+    public void try_get_should_return_value_if_key_exists()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -125,7 +125,7 @@ public class DatabaseIOTests : TestBase
         });
     }
 
-    public void CanCommitTransactionToNamedDatabase()
+    public void can_commit_transaction_to_named_database()
     {
         using var env = CreateEnvironment(TempPath(), new EnvironmentConfiguration{MaxDatabases = 2});
         env.Open();

--- a/src/LightningDB.Tests/EnvironmentTests.cs
+++ b/src/LightningDB.Tests/EnvironmentTests.cs
@@ -6,7 +6,7 @@ namespace LightningDB.Tests;
 
 public class EnvironmentTests : TestBase
 {
-    public void CanGetEnvironmentVersion()
+    public void can_get_environment_version()
     {
         using var env = CreateEnvironment();
         var version = env.Version;
@@ -14,13 +14,13 @@ public class EnvironmentTests : TestBase
         version.Minor.ShouldBeGreaterThan(0);
     }
 
-    public void EnvironmentShouldBeCreatedIfWithoutFlags()
+    public void environment_should_be_created_if_without_flags()
     {
         using var env = CreateEnvironment();
         env.Open();
     }
 
-    public void EnvironmentCreatedFromConfig()
+    public void environment_created_from_config()
     {
         const int mapExpected = 1024*1024*20;
         const int maxDatabaseExpected = 2;
@@ -32,13 +32,13 @@ public class EnvironmentTests : TestBase
         env.MaxReaders.ShouldBe(maxReadersExpected);
     }
 
-    public void StartingTransactionBeforeEnvironmentOpen()
+    public void starting_transaction_before_environment_open()
     {
         using var env = CreateEnvironment();
         Should.Throw<InvalidOperationException>(() => env.BeginTransaction());
     }
 
-    public void CanGetEnvironmentInfo()
+    public void can_get_environment_info()
     {
         const long mapSize = 1024 * 1024 * 200;
         using var env = CreateEnvironment(config: new EnvironmentConfiguration
@@ -50,8 +50,8 @@ public class EnvironmentTests : TestBase
         info.MapSize.ShouldBe(env.MapSize);
     }
 
-    public void CanGetLargeEnvironmentInfoOnlyOn64BitPlatform()
-    { 
+    public void can_get_large_environment_info_only_on_64bit_platform()
+    {
         const long mapSize = 1024 * 1024 * 1024 * 3L;
         using var env = CreateEnvironment(config: new EnvironmentConfiguration
         {
@@ -62,7 +62,7 @@ public class EnvironmentTests : TestBase
         env.MapSize.ShouldBe(info.MapSize);
     }
 
-    public void MaxDatabasesWorksThroughConfigIssue62()
+    public void max_databases_works_through_config_issue_62()
     {
         var config = new EnvironmentConfiguration { MaxDatabases = 2 };
         using var env = CreateEnvironment(config: config);
@@ -76,14 +76,14 @@ public class EnvironmentTests : TestBase
         env.MaxDatabases.ShouldBe(2);
     }
 
-    public void CanLoadAndDisposeMultipleEnvironments()
+    public void can_load_and_dispose_multiple_environments()
     {
         var env = CreateEnvironment();
         env.Dispose();
         using var env2 = CreateEnvironment();
     }
 
-    public void EnvironmentShouldBeCreatedIfReadOnly()
+    public void environment_should_be_created_if_read_only()
     {
         var env = CreateEnvironment();
         env.Open(); //readonly requires environment to have been created at least once before
@@ -93,7 +93,7 @@ public class EnvironmentTests : TestBase
             env.Open(EnvironmentOpenFlags.ReadOnly);
     }
 
-    public void EnvironmentShouldBeOpened()
+    public void environment_should_be_opened()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -101,7 +101,7 @@ public class EnvironmentTests : TestBase
         env.IsOpened.ShouldBeTrue();
     }
 
-    public void EnvironmentShouldBeClosed()
+    public void environment_should_be_closed()
     {
         var env = CreateEnvironment();
         env.Open();
@@ -109,7 +109,7 @@ public class EnvironmentTests : TestBase
         env.IsOpened.ShouldBeFalse();
     }
 
-    public void CanPutMultipleKeyValuePairsAndFlushSuccessfully()
+    public void can_put_multiple_key_value_pairs_and_flush_successfully()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -130,7 +130,7 @@ public class EnvironmentTests : TestBase
         result.ShouldBe(MDBResultCode.Success);
     }
 
-    public void EnvironmentShouldBeCopied()
+    public void environment_should_be_copied()
     {
         void CopyTest(bool compact)
         {
@@ -147,29 +147,260 @@ public class EnvironmentTests : TestBase
         CopyTest(false);
     }
 
-    public void EnvironmentShouldFailCopyIfPathIsFile()
+    public void environment_should_fail_copy_if_path_is_file()
     {
         using var env = CreateEnvironment();
         env.Open();
 
         var filePath = Path.Combine(TempPath(), "test.txt");
         File.WriteAllBytes(filePath, Array.Empty<byte>());
-        
+
         MDBResultCode result = env.CopyTo(filePath);
         result.ShouldNotBe(MDBResultCode.Success);
     }
 
-    public void CanOpenEnvironmentMoreThan50Mb()
+    public void can_open_environment_more_than_50mb()
     {
         using var env = CreateEnvironment();
         env.MapSize = 55 * 1024 * 1024;
         env.Open();
     }
-    
-    public void CanOpenEnvironmentWithSpecialCharacters()
+
+    public void can_open_environment_with_special_characters()
     {
         //all include special character now
-        using var env = new LightningEnvironment(TempPath("ß"));
+        using var env = CreateEnvironment(TempPath("ß"));
         env.Open();
+    }
+
+    public void can_get_and_set_flags()
+    {
+        using var env = CreateEnvironment();
+        env.Open();
+
+        var flags = env.Flags;
+
+        env.Flags = flags;
+
+        env.Flags = EnvironmentOpenFlags.None;
+        env.Flags.ShouldBe(EnvironmentOpenFlags.None);
+
+        env.Flags = EnvironmentOpenFlags.NoSync;
+        env.Flags.ShouldBe(EnvironmentOpenFlags.NoSync);
+
+        env.Flags = EnvironmentOpenFlags.NoSync | EnvironmentOpenFlags.NoMetaSync;
+        env.Flags.ShouldBe(EnvironmentOpenFlags.NoSync | EnvironmentOpenFlags.NoMetaSync);
+
+        env.Flags.HasFlag(EnvironmentOpenFlags.NoSync).ShouldBeTrue();
+        env.Flags.HasFlag(EnvironmentOpenFlags.NoMetaSync).ShouldBeTrue();
+
+        env.Flags = flags;
+        env.Flags.ShouldBe(flags);
+    }
+
+    public void can_check_stale_readers()
+    {
+        using var env = CreateEnvironment();
+        env.Open();
+
+        var staleReaders = env.CheckStaleReaders();
+        staleReaders.ShouldBeGreaterThanOrEqualTo(0); // Should be 0 if no stale readers
+    }
+
+    public void should_get_version_info()
+    {
+        using var env = CreateEnvironment();
+        var versionInfo = env.Version;
+
+        // Verify version info properties are valid
+        versionInfo.ShouldNotBeNull();
+        versionInfo.Major.ShouldBeGreaterThanOrEqualTo(0);
+        versionInfo.Minor.ShouldBeGreaterThan(0);
+        versionInfo.Patch.ShouldBeGreaterThanOrEqualTo(0);
+    }
+
+    public void should_get_version_string()
+    {
+        using var env = CreateEnvironment();
+        var versionInfo = env.Version;
+
+        // LightningVersionInfo doesn't override ToString(), so it returns the type name
+        // Just check that it returns a non-empty string
+        var versionString = versionInfo.ToString();
+        versionString.ShouldNotBeNullOrEmpty();
+    }
+
+    public void should_get_version_description()
+    {
+        using var env = CreateEnvironment();
+        var versionInfo = env.Version;
+
+        var versionDesc = versionInfo.Version;
+        versionDesc.ShouldNotBeNullOrEmpty();
+
+        // Version description should contain the library name and version
+        versionDesc.ToLowerInvariant().ShouldContain("lmdb");
+    }
+
+    public void can_copy_to_file_stream()
+    {
+        // Setup a source environment with some data
+        using var sourceEnv = CreateEnvironment();
+        sourceEnv.Open();
+
+        // Add some data to the source environment
+        using (var tx = sourceEnv.BeginTransaction())
+        using (var db = tx.OpenDatabase(null, new DatabaseConfiguration { Flags = DatabaseOpenFlags.Create }))
+        {
+            for (int i = 0; i < 5; i++)
+            {
+                tx.Put(db, $"key{i}", $"value{i}");
+            }
+            tx.Commit();
+        }
+
+        // Create a temporary file for the copy
+        var tempFilePath = Path.Combine(TempPath(), "env_copy.mdb");
+
+        // Ensure directory exists
+        Directory.CreateDirectory(Path.GetDirectoryName(tempFilePath));
+
+        // Create a FileStream to the destination file
+        using (var fileStream = new FileStream(tempFilePath, FileMode.Create, FileAccess.ReadWrite))
+        {
+            // Copy the environment to the FileStream
+            var result = sourceEnv.CopyToStream(fileStream);
+            result.ShouldBe(MDBResultCode.Success);
+        }
+
+        // Verify the file exists and has content
+        File.Exists(tempFilePath).ShouldBeTrue("Destination file should exist");
+        new FileInfo(tempFilePath).Length.ShouldBeGreaterThan(0, "Destination file should have content");
+    }
+
+    public void can_copy_with_compaction_to_file_stream()
+    {
+        // Setup a source environment with some data
+        using var sourceEnv = CreateEnvironment();
+        sourceEnv.Open();
+
+        // Add some data to the source environment and then delete half of it to create free space
+        using (var tx = sourceEnv.BeginTransaction())
+        using (var db = tx.OpenDatabase(null, new DatabaseConfiguration { Flags = DatabaseOpenFlags.Create }))
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                tx.Put(db, $"key{i}", $"value{i}");
+            }
+            tx.Commit();
+        }
+
+        // Delete some entries to create free space for compaction
+        using (var tx = sourceEnv.BeginTransaction())
+        using (var db = tx.OpenDatabase())
+        {
+            for (int i = 0; i < 5; i++)
+            {
+                tx.Delete(db, $"key{i}");
+            }
+            tx.Commit();
+        }
+
+        // Create a temporary file for the copy
+        var tempFilePath = Path.Combine(TempPath(), "env_copy_compact.mdb");
+
+        // Ensure directory exists
+        Directory.CreateDirectory(Path.GetDirectoryName(tempFilePath));
+
+        // Create a FileStream to the destination file
+        using (var fileStream = new FileStream(tempFilePath, FileMode.Create, FileAccess.ReadWrite))
+        {
+            // Copy the environment to the FileStream with compaction
+            var result = sourceEnv.CopyToStream(fileStream, compact: true);
+            result.ShouldBe(MDBResultCode.Success);
+        }
+
+        // Verify the file exists and has content
+        File.Exists(tempFilePath).ShouldBeTrue("Destination file should exist");
+        new FileInfo(tempFilePath).Length.ShouldBeGreaterThan(0, "Destination file should have content");
+    }
+
+    public void can_get_environment_file_stream()
+    {
+        // Skip this test on platforms where SafeFileHandle creation might not be supported
+        using var env = CreateEnvironment();
+        env.Open();
+
+        // Add some data to make sure the file has content
+        using (var tx = env.BeginTransaction())
+        using (var db = tx.OpenDatabase(null, new DatabaseConfiguration { Flags = DatabaseOpenFlags.Create }))
+        {
+            tx.Put(db, "testkey", "testvalue");
+            tx.Commit();
+        }
+
+        // Try to get a FileStream for the environment
+        using var fileStream = env.GetFileStream();
+
+        // Verify the FileStream is valid
+        fileStream.ShouldNotBeNull();
+        fileStream.CanRead.ShouldBeTrue();
+
+        // Should be able to read data from the beginning of the file
+        fileStream.Position = 0;
+        var buffer = new byte[16];
+        int bytesRead = fileStream.Read(buffer, 0, buffer.Length);
+
+        // We should have read some data (the exact content depends on LMDB format)
+        bytesRead.ShouldBeGreaterThan(0);
+    }
+
+    public void stream_throws_exception_for_null_argument()
+    {
+        using var env = CreateEnvironment();
+        env.Open();
+
+        // Null FileStream
+        Should.Throw<ArgumentNullException>(() => env.CopyToStream(null));
+    }
+
+    public void stream_throws_exception_for_read_only_file_stream()
+    {
+        using var env = CreateEnvironment();
+        env.Open();
+
+        // Create a temporary file
+        var tempFilePath = Path.Combine(TempPath(), "temp.txt");
+        File.WriteAllText(tempFilePath, "test");
+
+        // Open as read-only and verify it throws the expected exception
+        using var readOnlyStream = new FileStream(tempFilePath, FileMode.Open, FileAccess.Read);
+        Should.Throw<ArgumentException>(() => env.CopyToStream(readOnlyStream));
+    }
+
+    public void can_get_max_key_size()
+    {
+        using var env = CreateEnvironment();
+        env.Open();
+
+        // Get the maximum key size
+        var maxKeySize = env.MaxKeySize;
+
+        // The default max key size for LMDB is typically 511 bytes for non-dupsort databases
+        // But we'll just verify it's a reasonable, positive value
+        maxKeySize.ShouldBeGreaterThan(0);
+
+        // Typical value is 511 or 511 * 4 (for larger page sizes)
+        // Let's verify it's at least 100 bytes, which should be true for all configurations
+        maxKeySize.ShouldBeGreaterThanOrEqualTo(100);
+    }
+
+    public void max_key_size_throws_when_environment_not_opened()
+    {
+        using var env = CreateEnvironment();
+        // Don't open the environment
+
+        // Attempting to get MaxKeySize should throw, as the environment must be opened
+        Should.Throw<InvalidOperationException>(() => { _ = env.MaxKeySize; });
     }
 }

--- a/src/LightningDB.Tests/TransactionTests.cs
+++ b/src/LightningDB.Tests/TransactionTests.cs
@@ -8,7 +8,7 @@ namespace LightningDB.Tests;
 
 public class TransactionTests : TestBase
 {
-    public void CanDeletePreviouslyCommittedWithMultipleValuesByPassingNullForValue()
+    public void can_delete_previously_committed_with_multiple_values_by_passing_null_for_value()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -20,7 +20,7 @@ public class TransactionTests : TestBase
             tx.Put(db, key, MemoryMarshal.Cast<char, byte>("Value2"), PutOptions.AppendData);
             tx.Commit();
             tx.Dispose();
-                
+
             using var delTxn = env.BeginTransaction();
             var result = delTxn.Delete(db, key, null);
             result.ShouldBe(MDBResultCode.Success);
@@ -29,7 +29,7 @@ public class TransactionTests : TestBase
         }, DatabaseOpenFlags.Create | DatabaseOpenFlags.DuplicatesFixed);
     }
 
-    public void TransactionShouldBeCreated()
+    public void transaction_should_be_created()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -39,7 +39,7 @@ public class TransactionTests : TestBase
         });
     }
 
-    public void TransactionShouldChangeStateOnCommit()
+    public void transaction_should_change_state_on_commit()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -50,7 +50,7 @@ public class TransactionTests : TestBase
         });
     }
 
-    public void ChildTransactionShouldBeCreated()
+    public void child_transaction_should_be_created()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -62,7 +62,7 @@ public class TransactionTests : TestBase
         });
     }
 
-    public void ResetTransactionAbortedOnDispose()
+    public void reset_transaction_aborted_on_dispose()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -74,7 +74,7 @@ public class TransactionTests : TestBase
         }, transactionFlags: TransactionBeginFlags.ReadOnly);
     }
 
-    public void ChildTransactionShouldBeAbortedIfParentIsAborted()
+    public void child_transaction_should_be_aborted_if_parent_is_aborted()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -86,8 +86,8 @@ public class TransactionTests : TestBase
             result.ShouldBe(MDBResultCode.BadTxn);
         });
     }
-    
-    public void TryGetShouldVerifyFindingAndNotFindingValues()
+
+    public void try_get_should_verify_finding_and_not_finding_values()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -95,18 +95,18 @@ public class TransactionTests : TestBase
         {
             var key = MemoryMarshal.Cast<char, byte>("key1");
             var value = MemoryMarshal.Cast<char, byte>("value1");
-    
+
             tx.Put(db, key, value);
-    
+
             tx.TryGet(db, key.ToArray(), out var retrievedValue).ShouldBeTrue();
             retrievedValue.ShouldBe(value.ToArray());
-    
+
             var missingKey = MemoryMarshal.Cast<char, byte>("key2");
             tx.TryGet(db, missingKey.ToArray(), out _).ShouldBeFalse();
         });
     }
-    
-    public void TryGetWithKeyAndValueShouldBeFound()
+
+    public void try_get_with_key_and_value_should_be_found()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -115,14 +115,14 @@ public class TransactionTests : TestBase
             var key = MemoryMarshal.Cast<char, byte>("key3");
             var value = MemoryMarshal.Cast<char, byte>("value3");
             tx.Put(db, key, value);
-    
+
             var resultBuffer = new byte[value.Length];
             tx.TryGet(db, key.ToArray(), resultBuffer).ShouldBeTrue();
             resultBuffer.ShouldBe(value.ToArray());
         });
     }
 
-    public void ChildTransactionShouldBeAbortedIfParentIsCommitted()
+    public void child_transaction_should_be_aborted_if_parent_is_committed()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -136,7 +136,7 @@ public class TransactionTests : TestBase
     }
 
 
-    public void ReadOnlyTransactionShouldChangeStateOnReset()
+    public void read_only_transaction_should_change_state_on_reset()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -147,7 +147,7 @@ public class TransactionTests : TestBase
         }, transactionFlags: TransactionBeginFlags.ReadOnly);
     }
 
-    public void ReadOnlyTransactionShouldChangeStateOnRenew()
+    public void read_only_transaction_should_change_state_on_renew()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -159,7 +159,7 @@ public class TransactionTests : TestBase
         }, transactionFlags: TransactionBeginFlags.ReadOnly);
     }
 
-    public void CanCountTransactionEntries()
+    public void can_count_transaction_entries()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -174,21 +174,21 @@ public class TransactionTests : TestBase
         });
     }
 
-    public void CanGetDatabaseStatistics()
+    public void can_get_database_statistics()
     {
         using var env = CreateEnvironment();
         env.Open();
         env.RunTransactionScenario((commitTx, db) =>
         {
             commitTx.Commit().ThrowOnError();
-            
+
             Should.Throw<LightningException>(() => db.DatabaseStats);
 
             const int entriesCount = 5;
             using var tx = env.BeginTransaction();
             for (var i = 0; i < entriesCount; i++)
                 tx.Put(db, i.ToString(), i.ToString()).ThrowOnError();
-            
+
             var stats = tx.GetStats(db);
             stats.Entries.ShouldBe(entriesCount);
             stats.BranchPages.ShouldBe(0);
@@ -199,7 +199,7 @@ public class TransactionTests : TestBase
         });
     }
 
-    public void TransactionShouldSupportCustomComparer()
+    public void transaction_should_support_custom_comparer()
     {
         int Comparison(int l, int r) => l.CompareTo(r);
         var options = new DatabaseConfiguration {Flags = DatabaseOpenFlags.Create};
@@ -235,7 +235,7 @@ public class TransactionTests : TestBase
         }
     }
 
-    public void TransactionShouldSupportCustomDupSorter()
+    public void transaction_should_support_custom_dup_sorter()
     {
         int Comparison(int l, int r) => -Math.Sign(l - r);
 
@@ -263,7 +263,7 @@ public class TransactionTests : TestBase
                 BitConverter.ToInt32(result.Item3.CopyToNewArray()).ShouldBe(valuesSorted[order++]);
         }
     }
-    public void DatabaseShouldBeEmptyAfterTruncate()
+    public void database_should_be_empty_after_truncate()
     {
         using var env = CreateEnvironment();
         env.Open();
@@ -284,6 +284,244 @@ public class TransactionTests : TestBase
             // Verify the database is empty
             tx.ContainsKey(db, key1).ShouldBeFalse();
             tx.ContainsKey(db, key2).ShouldBeFalse();
+        });
+    }
+
+    public void can_get_transaction_id()
+    {
+        using var env = CreateEnvironment();
+        env.Open();
+
+        env.RunTransactionScenario((tx, _) =>
+        {
+            tx.Id.ShouldBeGreaterThan(0);
+        });
+    }
+
+    public void can_compare_key_values()
+    {
+        using var env = CreateEnvironment();
+        env.Open();
+
+        env.RunTransactionScenario((tx, db) =>
+        {
+            var key1 = MemoryMarshal.Cast<char, byte>("aaa");
+            var key2 = MemoryMarshal.Cast<char, byte>("bbb");
+
+            // Key1 should be less than Key2
+            tx.CompareKeys(db, key1, key2).ShouldBeLessThan(0);
+
+            // Key2 should be greater than Key1
+            tx.CompareKeys(db, key2, key1).ShouldBeGreaterThan(0);
+
+            // Same keys should be equal
+            tx.CompareKeys(db, key1, key1).ShouldBe(0);
+        });
+    }
+
+    public void can_compare_data_values()
+    {
+        using var env = CreateEnvironment();
+        // Set MaxDatabases to allow creating the extra test database
+        env.MaxDatabases = 10;
+        env.Open();
+
+        env.RunTransactionScenario((tx, db) =>
+        {
+            // Test with a database that supports duplicates for data comparison
+            var dbConfig = new DatabaseConfiguration { Flags = DatabaseOpenFlags.Create | DatabaseOpenFlags.DuplicatesSort };
+            using var dupsDb = tx.OpenDatabase("dups_db", dbConfig);
+
+            var data1 = MemoryMarshal.Cast<char, byte>("value1");
+            var data2 = MemoryMarshal.Cast<char, byte>("value2");
+
+            // Data1 should be less than Data2
+            tx.CompareData(dupsDb, data1, data2).ShouldBeLessThan(0);
+
+            // Data2 should be greater than Data1
+            tx.CompareData(dupsDb, data2, data1).ShouldBeGreaterThan(0);
+
+            // Same data values should be equal
+            tx.CompareData(dupsDb, data1, data1).ShouldBe(0);
+        });
+    }
+
+    public void should_use_no_overwrite_option()
+    {
+        using var env = CreateEnvironment();
+        env.Open();
+        env.RunTransactionScenario((tx, db) =>
+        {
+            var key = MemoryMarshal.Cast<char, byte>("testKey");
+            var value1 = MemoryMarshal.Cast<char, byte>("value1");
+            var value2 = MemoryMarshal.Cast<char, byte>("value2");
+
+            // First put succeeds
+            var result = tx.Put(db, key, value1);
+            result.ShouldBe(MDBResultCode.Success);
+
+            // Second put with NoOverwrite should fail with KeyExist
+            result = tx.Put(db, key, value2, PutOptions.NoOverwrite);
+            result.ShouldBe(MDBResultCode.KeyExist);
+
+            // Value should remain unchanged
+            tx.TryGet(db, key.ToArray(), out var retrievedValue).ShouldBeTrue();
+            retrievedValue.ShouldBe(value1.ToArray());
+        });
+    }
+
+    public void should_use_no_duplicate_data_option()
+    {
+        using var env = CreateEnvironment();
+        env.Open();
+        env.RunTransactionScenario((tx, db) =>
+        {
+            var key = MemoryMarshal.Cast<char, byte>("testKey");
+            var value1 = MemoryMarshal.Cast<char, byte>("value1");
+            var value2 = MemoryMarshal.Cast<char, byte>("value2");
+
+            // Put first value
+            var result = tx.Put(db, key, value1);
+            result.ShouldBe(MDBResultCode.Success);
+
+            // Put second value
+            result = tx.Put(db, key, value2);
+            result.ShouldBe(MDBResultCode.Success);
+
+            // Try to put first value again with NoDuplicateData, should fail
+            result = tx.Put(db, key, value1, PutOptions.NoDuplicateData);
+            result.ShouldBe(MDBResultCode.KeyExist);
+
+            // Different value should succeed
+            var value3 = MemoryMarshal.Cast<char, byte>("value3");
+            result = tx.Put(db, key, value3, PutOptions.NoDuplicateData);
+            result.ShouldBe(MDBResultCode.Success);
+        }, DatabaseOpenFlags.Create | DatabaseOpenFlags.DuplicatesSort);
+    }
+
+    public void should_use_append_data_option()
+    {
+        using var env = CreateEnvironment();
+        env.Open();
+        env.RunTransactionScenario((tx, db) =>
+        {
+            // Create sorted keys
+            var keys = Enumerable.Range(1, 5)
+                .Select(i => MemoryMarshal.Cast<char, byte>($"key{i:D5}").ToArray())
+                .ToArray();
+
+            // Insert keys in order with AppendData option
+            foreach (var key in keys)
+            {
+                var result = tx.Put(db, key, key, PutOptions.AppendData);
+                result.ShouldBe(MDBResultCode.Success);
+            }
+
+            // Verify all keys were inserted correctly
+            for (int i = 0; i < keys.Length; i++)
+            {
+                tx.TryGet(db, keys[i].ToArray(), out var value).ShouldBeTrue();
+                value.ShouldBe(keys[i].ToArray());
+            }
+
+            // Inserting in wrong order should fail with KeyExist,
+            var outOfOrderKey = MemoryMarshal.Cast<char, byte>("key00000");
+            var putResult = tx.Put(db, outOfOrderKey, outOfOrderKey, PutOptions.AppendData);
+            putResult.ShouldBe(MDBResultCode.KeyExist);
+            var entriesCount = tx.GetEntriesCount(db);
+            entriesCount.ShouldBeGreaterThanOrEqualTo(keys.Length);
+        });
+    }
+
+    public void should_use_append_duplicate_data_option()
+    {
+        using var env = CreateEnvironment();
+        env.Open();
+        env.RunTransactionScenario((tx, db) =>
+        {
+            var key = MemoryMarshal.Cast<char, byte>("testKey");
+
+            // Create sorted values
+            var values = Enumerable.Range(1, 5)
+                .Select(i => MemoryMarshal.Cast<char, byte>($"value{i:D5}").ToArray())
+                .ToArray();
+
+            // Insert first value normally
+            var result = tx.Put(db, key, values[0]);
+            result.ShouldBe(MDBResultCode.Success);
+
+            // Insert remaining values in order with AppendDuplicateData option
+            for (int i = 1; i < values.Length; i++)
+            {
+                result = tx.Put(db, key, values[i], PutOptions.AppendDuplicateData);
+                result.ShouldBe(MDBResultCode.Success);
+            }
+
+            // Check that all values are associated with the key
+            using var cursor = tx.CreateCursor(db);
+            cursor.Set(key.ToArray());
+            var count = 0;
+            do
+            {
+                var (resultCode, retrievedKey, retrievedValue) = cursor.GetCurrent();
+                resultCode.ShouldBe(MDBResultCode.Success);
+                count++;
+            } while (cursor.NextDuplicate().resultCode == MDBResultCode.Success);
+
+            count.ShouldBe(values.Length);
+        }, DatabaseOpenFlags.Create | DatabaseOpenFlags.DuplicatesSort);
+    }
+
+    public void should_handle_combined_put_options()
+    {
+        using var env = CreateEnvironment();
+        env.Open();
+        env.RunTransactionScenario((tx, db) =>
+        {
+            var key = MemoryMarshal.Cast<char, byte>("testKey");
+            var value1 = MemoryMarshal.Cast<char, byte>("value1");
+            var value2 = MemoryMarshal.Cast<char, byte>("value2");
+
+            // First put succeeds
+            var result = tx.Put(db, key, value1);
+            result.ShouldBe(MDBResultCode.Success);
+
+            // Combined options: NoOverwrite | AppendData
+            // Since NoOverwrite will prevent overwriting the key,
+            // AppendData won't matter in this case
+            result = tx.Put(db, key, value2, PutOptions.NoOverwrite | PutOptions.AppendData);
+            result.ShouldBe(MDBResultCode.KeyExist);
+
+            // Value should remain unchanged
+            tx.TryGet(db, key.ToArray(), out var retrievedValue).ShouldBeTrue();
+            retrievedValue.ShouldBe(value1.ToArray());
+        });
+    }
+
+    public void should_handle_reserve_space_option()
+    {
+        using var env = CreateEnvironment();
+        env.Open();
+        env.RunTransactionScenario((tx, db) =>
+        {
+            var key = MemoryMarshal.Cast<char, byte>("reserveKey");
+
+            // Create a value with a specific size
+            var valueSize = 128;
+            var value = new byte[valueSize];
+            for (int i = 0; i < valueSize; i++)
+            {
+                value[i] = (byte)(i % 256);
+            }
+
+            // In a real implementation with ReserveSpace, you'd get a pointer
+            // to fill directly, but for testing we can just verify it works
+            var result = tx.Put(db, key, value, PutOptions.ReserveSpace);
+
+            // This option is mostly used for direct memory manipulation
+            // which is difficult to test in a managed environment
+            // We can at least verify the key exists
+            tx.ContainsKey(db, key).ShouldBeTrue();
         });
     }
 }

--- a/src/LightningDB/DatabaseOpenFlags.cs
+++ b/src/LightningDB/DatabaseOpenFlags.cs
@@ -13,7 +13,7 @@ public enum DatabaseOpenFlags
     /// No special options.
     /// </summary>
     None = 0,
-                
+    
     /// <summary>
     /// MDB_REVERSEKEY. Keys are strings to be compared in reverse order, from the end of the strings to the beginning. By default, Keys are treated as strings and compared from beginning to end.
     /// </summary>
@@ -22,7 +22,7 @@ public enum DatabaseOpenFlags
     /// <summary>
     /// MDB_DUPSORT. Duplicate keys may be used in the database. (Or, from another perspective, keys may have multiple data items, stored in sorted order.) By default keys must be unique and may have only a single data item.
     /// </summary>
-    DuplicatesSort = Lmdb.MDB_DUPSORT,
+    DuplicatesSort = 0x04,
 
     /// <summary>
     /// MDB_INTEGERKEY. Keys are binary integers in native byte order. 
@@ -33,7 +33,7 @@ public enum DatabaseOpenFlags
     /// <summary>
     /// MDB_DUPFIXED. This flag may only be used in combination with MDB_DUPSORT. This option tells the library that the data items for this database are all the same size, which allows further optimizations in storage and retrieval. When all data items are the same size, the MDB_GET_MULTIPLE and MDB_NEXT_MULTIPLE cursor operations may be used to retrieve multiple items at once.
     /// </summary>
-    DuplicatesFixed = Lmdb.MDB_DUPSORT | Lmdb.MDB_DUPFIXED,
+    DuplicatesFixed = DuplicatesSort | 0x10,
 
     /// <summary>
     /// MDB_INTEGERDUP. This option specifies that duplicate data items are also integers, and should be sorted as such.

--- a/src/LightningDB/LightningTransaction.cs
+++ b/src/LightningDB/LightningTransaction.cs
@@ -346,6 +346,55 @@ public sealed class LightningTransaction : IDisposable
     /// Whether this transaction is read-only.
     /// </summary>
     public bool IsReadOnly { get; }
+    
+    /// <summary>
+    /// Gets the transaction ID.
+    /// </summary>
+    public int Id => mdb_txn_id(_handle);
+    
+    /// <summary>
+    /// Compares two data items according to the database's key comparison function.
+    /// </summary>
+    /// <param name="db">The database to use for comparison</param>
+    /// <param name="a">First item to compare</param>
+    /// <param name="b">Second item to compare</param>
+    /// <returns>Negative value if a is less than b, zero if equal, positive if a is greater than b</returns>
+    public unsafe int CompareKeys(LightningDatabase db, ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
+    {
+        if (db == null)
+            throw new ArgumentNullException(nameof(db));
+            
+        fixed (byte* aPtr = a)
+        fixed (byte* bPtr = b)
+        {
+            var mdbA = new MDBValue(a.Length, aPtr);
+            var mdbB = new MDBValue(b.Length, bPtr);
+            
+            return mdb_cmp(_handle, db._handle, ref mdbA, ref mdbB);
+        }
+    }
+    
+    /// <summary>
+    /// Compares two data items according to the database's data comparison function.
+    /// </summary>
+    /// <param name="db">The database to use for comparison</param>
+    /// <param name="a">First item to compare</param>
+    /// <param name="b">Second item to compare</param>
+    /// <returns>Negative value if a is less than b, zero if equal, positive if a is greater than b</returns>
+    public unsafe int CompareData(LightningDatabase db, ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
+    {
+        if (db == null)
+            throw new ArgumentNullException(nameof(db));
+            
+        fixed (byte* aPtr = a)
+        fixed (byte* bPtr = b)
+        {
+            var mdbA = new MDBValue(a.Length, aPtr);
+            var mdbB = new MDBValue(b.Length, bPtr);
+            
+            return mdb_dcmp(_handle, db._handle, ref mdbA, ref mdbB);
+        }
+    }
 
     /// <summary>
     /// Abort this transaction and deallocate all resources associated with it (including databases).

--- a/src/LightningDB/Native/Lmdb.cs
+++ b/src/LightningDB/Native/Lmdb.cs
@@ -10,150 +10,577 @@ using System.Runtime.CompilerServices;
 public static partial class Lmdb
 {
 #if NET7_0_OR_GREATER
+    /// <summary>
+    /// Creates an LMDB environment handle.
+    /// </summary>
+    /// <param name="env">The address where the new handle will be stored</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_env_create(out nint env); 
         
+    /// <summary>
+    /// Closes the environment and releases the memory map.
+    /// </summary>
+    /// <param name="env">The environment handle to close</param>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial void mdb_env_close(nint env);
         
+    /// <summary>
+    /// Opens an environment handle with the specified path, flags, and permissions.
+    /// </summary>
+    /// <param name="env">The environment handle to open</param>
+    /// <param name="path">The directory in which the database files reside</param>
+    /// <param name="flags">Special options for this environment</param>
+    /// <param name="mode">The UNIX permissions to set on created files</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME, StringMarshalling = StringMarshalling.Utf8)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_env_open(nint env, string path, EnvironmentOpenFlags flags, UnixAccessMode mode);
         
+    /// <summary>
+    /// Sets the size of the memory map to use for this environment.
+    /// </summary>
+    /// <param name="env">The environment handle</param>
+    /// <param name="size">The size in bytes</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_env_set_mapsize(nint env, nint size);
         
+    /// <summary>
+    /// Gets the maximum number of threads/reader slots for the environment.
+    /// </summary>
+    /// <param name="env">The environment handle</param>
+    /// <param name="readers">Address where the number of readers will be stored</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_env_get_maxreaders(nint env, out uint readers);
         
+    /// <summary>
+    /// Sets the maximum number of threads/reader slots for the environment.
+    /// </summary>
+    /// <param name="env">The environment handle</param>
+    /// <param name="readers">The number of reader slots to allocate</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_env_set_maxreaders(nint env, uint readers);
         
+    /// <summary>
+    /// Sets the maximum number of named databases for the environment.
+    /// </summary>
+    /// <param name="env">The environment handle</param>
+    /// <param name="dbs">The maximum number of databases</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_env_set_maxdbs(nint env, uint dbs);
+    
+    /// <summary>
+    /// Sets environment flags.
+    /// </summary>
+    /// <param name="env">The environment handle</param>
+    /// <param name="flags">The flags to set</param>
+    /// <param name="onoff">A boolean to turn the flags on or off</param>
+    /// <returns>A result code indicating success or failure</returns>
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial MDBResultCode mdb_env_set_flags(nint env, uint flags, [MarshalAs(UnmanagedType.I1)] bool onoff);
+    
+    /// <summary>
+    /// Gets environment flags.
+    /// </summary>
+    /// <param name="env">The environment handle</param>
+    /// <param name="flags">Address where the flags will be stored</param>
+    /// <returns>A result code indicating success or failure</returns>
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial MDBResultCode mdb_env_get_flags(nint env, out uint flags);
+    
+    /// <summary>
+    /// Returns the path that was used in mdb_env_open.
+    /// </summary>
+    /// <param name="env">The environment handle</param>
+    /// <param name="path">Address where the path will be stored</param>
+    /// <returns>A result code indicating success or failure</returns>
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial MDBResultCode mdb_env_get_path(nint env, out nint path);
+    
+    /// <summary>
+    /// Returns the file descriptor for the environment.
+    /// </summary>
+    /// <param name="env">The environment handle</param>
+    /// <param name="fd">Address where the descriptor will be stored</param>
+    /// <returns>A result code indicating success or failure</returns>
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial MDBResultCode mdb_env_get_fd(nint env, out nint fd);
+    
+    /// <summary>
+    /// Returns the maximum size of keys and MDB_DUPSORT data we can write.
+    /// </summary>
+    /// <param name="env">The environment handle</param>
+    /// <returns>The maximum size of a key we can write</returns>
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial int mdb_env_get_maxkeysize(nint env);
+    
+    /// <summary>
+    /// Set application information associated with the environment.
+    /// </summary>
+    /// <param name="env">The environment handle</param>
+    /// <param name="ctx">An arbitrary pointer for your application's use</param>
+    /// <returns>A result code indicating success or failure</returns>
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial MDBResultCode mdb_env_set_userctx(nint env, nint ctx);
+    
+    /// <summary>
+    /// Get the application information associated with the environment.
+    /// </summary>
+    /// <param name="env">The environment handle</param>
+    /// <returns>The pointer set by mdb_env_set_userctx</returns>
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial nint mdb_env_get_userctx(nint env);
+    
+    /// <summary>
+    /// Set or reset the assert callback for the environment.
+    /// </summary>
+    /// <param name="env">The environment handle</param>
+    /// <param name="func">A callback function to run when an assertion fails</param>
+    /// <returns>A result code indicating success or failure</returns>
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial MDBResultCode mdb_env_set_assert(nint env, nint func);
         
+    /// <summary>
+    /// Opens a database in the environment.
+    /// </summary>
+    /// <param name="txn">A transaction handle</param>
+    /// <param name="name">The name of the database to open (NULL for the main DB)</param>
+    /// <param name="flags">Special options for this database</param>
+    /// <param name="db">Address where the database handle will be stored</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME, StringMarshalling = StringMarshalling.Utf8)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_dbi_open(nint txn, string name, DatabaseOpenFlags flags, out uint db);
         
+    /// <summary>
+    /// Closes a database handle in the environment.
+    /// </summary>
+    /// <param name="env">The environment handle</param>
+    /// <param name="dbi">A database handle returned by mdb_dbi_open</param>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial void mdb_dbi_close(nint env, uint dbi);
+    
+    /// <summary>
+    /// Retrieves the flags for a database handle.
+    /// </summary>
+    /// <param name="txn">A transaction handle</param>
+    /// <param name="dbi">A database handle</param>
+    /// <param name="flags">Address where the flags will be stored</param>
+    /// <returns>A result code indicating success or failure</returns>
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial MDBResultCode mdb_dbi_flags(nint txn, uint dbi, out uint flags);
         
+    /// <summary>
+    /// Empties or deletes a database.
+    /// </summary>
+    /// <param name="txn">A transaction handle</param>
+    /// <param name="dbi">A database handle</param>
+    /// <param name="del">If true, delete the DB from the environment; otherwise just empty it</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_drop(nint txn, uint dbi, [MarshalAs(UnmanagedType.I1)] bool del);
         
+    /// <summary>
+    /// Creates a transaction for use with the environment.
+    /// </summary>
+    /// <param name="env">The environment handle</param>
+    /// <param name="parent">Parent transaction (for nested transactions; NULL for none)</param>
+    /// <param name="flags">Special transaction flags</param>
+    /// <param name="txn">Address where the new transaction handle will be stored</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_txn_begin(nint env, nint parent, TransactionBeginFlags flags, out nint txn);
+    
+    /// <summary>
+    /// Returns the transaction's environment.
+    /// </summary>
+    /// <param name="txn">A transaction handle</param>
+    /// <returns>The environment handle</returns>
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial nint mdb_txn_env(nint txn);
+    
+    /// <summary>
+    /// Returns the transaction's ID.
+    /// </summary>
+    /// <param name="txn">A transaction handle</param>
+    /// <returns>The transaction ID</returns>
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial int mdb_txn_id(nint txn);
         
+    /// <summary>
+    /// Commits all the operations of a transaction into the database.
+    /// </summary>
+    /// <param name="txn">A transaction handle</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_txn_commit(nint txn);
         
+    /// <summary>
+    /// Abandons all the operations of the transaction instead of saving them.
+    /// </summary>
+    /// <param name="txn">A transaction handle</param>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial void mdb_txn_abort(nint txn);
         
+    /// <summary>
+    /// Resets a read-only transaction.
+    /// </summary>
+    /// <param name="txn">A transaction handle</param>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial void mdb_txn_reset(nint txn);
         
+    /// <summary>
+    /// Renews a read-only transaction that was previously reset.
+    /// </summary>
+    /// <param name="txn">A transaction handle</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_txn_renew(nint txn);
         
+    /// <summary>
+    /// Returns the LMDB library version and version information.
+    /// </summary>
+    /// <param name="major">The library major version number</param>
+    /// <param name="minor">The library minor version number</param>
+    /// <param name="patch">The library patch version number</param>
+    /// <returns>Pointer to a version string</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial nint mdb_version(out int major, out int minor, out int patch);
         
+    /// <summary>
+    /// Returns a string describing a given error code.
+    /// </summary>
+    /// <param name="err">The error code</param>
+    /// <returns>A pointer to the error string</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial nint mdb_strerror(int err);
         
+    /// <summary>
+    /// Returns statistics about a database.
+    /// </summary>
+    /// <param name="txn">A transaction handle</param>
+    /// <param name="dbi">A database handle</param>
+    /// <param name="stat">Address where the database statistics will be stored</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_stat(nint txn, uint dbi, out MDBStat stat);
         
+    /// <summary>
+    /// Copies an LMDB environment to the specified path.
+    /// </summary>
+    /// <param name="env">The environment handle</param>
+    /// <param name="path">The directory in which the backup will reside</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME, StringMarshalling = StringMarshalling.Utf8)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_env_copy(nint env, string path);
+    
+    /// <summary>
+    /// Copies an LMDB environment to the specified file descriptor.
+    /// </summary>
+    /// <param name="env">The environment handle</param>
+    /// <param name="fd">The file descriptor to write to</param>
+    /// <returns>A result code indicating success or failure</returns>
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial MDBResultCode mdb_env_copyfd(nint env, nint fd);
         
+    /// <summary>
+    /// Copies an LMDB environment to the specified path, with options for compaction.
+    /// </summary>
+    /// <param name="env">The environment handle</param>
+    /// <param name="path">The directory in which the backup will reside</param>
+    /// <param name="copyFlags">Special options for this copy operation</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME, StringMarshalling = StringMarshalling.Utf8)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_env_copy2(nint env, string path, EnvironmentCopyFlags copyFlags);
+    
+    /// <summary>
+    /// Copies an LMDB environment to the specified file descriptor, with options for compaction.
+    /// </summary>
+    /// <param name="env">The environment handle</param>
+    /// <param name="fd">The file descriptor to write to</param>
+    /// <param name="copyFlags">Special options for this copy operation</param>
+    /// <returns>A result code indicating success or failure</returns>
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial MDBResultCode mdb_env_copyfd2(nint env, nint fd, EnvironmentCopyFlags copyFlags);
         
+    /// <summary>
+    /// Returns information about the LMDB environment.
+    /// </summary>
+    /// <param name="env">The environment handle</param>
+    /// <param name="stat">Address where the environment info will be stored</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_env_info(nint env, out MDBEnvInfo stat);
         
+    /// <summary>
+    /// Returns statistics about the LMDB environment.
+    /// </summary>
+    /// <param name="env">The environment handle</param>
+    /// <param name="stat">Address where the environment statistics will be stored</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_env_stat(nint env, out MDBStat stat);
         
+    /// <summary>
+    /// Flushes all data to the environment's data file.
+    /// </summary>
+    /// <param name="env">The environment handle</param>
+    /// <param name="force">If true, force a synchronous flush; otherwise if the environment has MDB_NOSYNC or MDB_MAPASYNC, it will not be synchronous</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_env_sync(nint env, [MarshalAs(UnmanagedType.I1)] bool force);
         
+    /// <summary>
+    /// Retrieves items from a database.
+    /// </summary>
+    /// <param name="txn">A transaction handle</param>
+    /// <param name="dbi">A database handle</param>
+    /// <param name="key">The key to search for</param>
+    /// <param name="data">Address where the retrieved data will be stored</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_get(nint txn, uint dbi, ref MDBValue key, out MDBValue data);
         
+    /// <summary>
+    /// Returns count of duplicates for the current key in a cursor.
+    /// </summary>
+    /// <param name="cursor">A cursor handle</param>
+    /// <param name="countp">Address where the count will be stored</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_cursor_count(nint cursor, out int countp);
         
+    /// <summary>
+    /// Stores key/data pairs in a database.
+    /// </summary>
+    /// <param name="txn">A transaction handle</param>
+    /// <param name="dbi">A database handle</param>
+    /// <param name="key">The key to store</param>
+    /// <param name="data">The data to store</param>
+    /// <param name="flags">Special options for this operation</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_put(nint txn, uint dbi, ref MDBValue key, ref MDBValue data, PutOptions flags);
         
+    /// <summary>
+    /// Deletes items from a database.
+    /// </summary>
+    /// <param name="txn">A transaction handle</param>
+    /// <param name="dbi">A database handle</param>
+    /// <param name="key">The key to delete</param>
+    /// <param name="data">The data to delete (only needed for MDB_DUPSORT)</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_del(nint txn, uint dbi, ref MDBValue key, ref MDBValue data);
         
+    /// <summary>
+    /// Deletes items from a database.
+    /// </summary>
+    /// <param name="txn">A transaction handle</param>
+    /// <param name="dbi">A database handle</param>
+    /// <param name="key">The key to delete</param>
+    /// <param name="data">NULL pointer to delete all of the data items for the key</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_del(nint txn, uint dbi, ref MDBValue key, nint data);
         
+    /// <summary>
+    /// Creates a cursor handle for the specified transaction and database.
+    /// </summary>
+    /// <param name="txn">A transaction handle</param>
+    /// <param name="dbi">A database handle</param>
+    /// <param name="cursor">Address where the new cursor handle will be stored</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_cursor_open(nint txn, uint dbi, out nint cursor);
         
+    /// <summary>
+    /// Closes a cursor handle.
+    /// </summary>
+    /// <param name="cursor">A cursor handle to close</param>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial void mdb_cursor_close(nint cursor);
         
+    /// <summary>
+    /// Renews a cursor handle.
+    /// </summary>
+    /// <param name="txn">A transaction handle</param>
+    /// <param name="cursor">A cursor handle to renew</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_cursor_renew(nint txn, nint cursor);
+    
+    /// <summary>
+    /// Returns the cursor's transaction handle.
+    /// </summary>
+    /// <param name="cursor">A cursor handle</param>
+    /// <returns>The transaction handle</returns>
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial nint mdb_cursor_txn(nint cursor);
+    
+    /// <summary>
+    /// Returns the cursor's database handle.
+    /// </summary>
+    /// <param name="cursor">A cursor handle</param>
+    /// <returns>The database handle</returns>
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial uint mdb_cursor_dbi(nint cursor);
         
+    /// <summary>
+    /// Retrieves key/data pairs from the database using a cursor.
+    /// </summary>
+    /// <param name="cursor">A cursor handle</param>
+    /// <param name="key">The key for the current item</param>
+    /// <param name="data">The data for the current item</param>
+    /// <param name="op">The cursor operation to perform</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_cursor_get(nint cursor, ref MDBValue key, ref MDBValue data, CursorOperation op);
         
+    /// <summary>
+    /// Stores key/data pairs into the database using a cursor.
+    /// </summary>
+    /// <param name="cursor">A cursor handle</param>
+    /// <param name="key">The key to store</param>
+    /// <param name="mdbValue">The data to store</param>
+    /// <param name="flags">Special options for this operation</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_cursor_put(nint cursor, ref MDBValue key, ref MDBValue mdbValue, CursorPutOptions flags);
         
+    /// <summary>
+    /// Deletes the current key/data pair to which the cursor refers.
+    /// </summary>
+    /// <param name="cursor">A cursor handle</param>
+    /// <param name="flags">Special options for this operation</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_cursor_del(nint cursor, CursorDeleteOption flags);
         
+    /// <summary>
+    /// Sets a custom key comparison function for a database.
+    /// </summary>
+    /// <param name="txn">A transaction handle</param>
+    /// <param name="dbi">A database handle</param>
+    /// <param name="cmp">The comparison function to set</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_set_compare(nint txn, uint dbi, CompareFunction cmp);
         
+    /// <summary>
+    /// Sets a custom data comparison function for a database with MDB_DUPSORT.
+    /// </summary>
+    /// <param name="txn">A transaction handle</param>
+    /// <param name="dbi">A database handle</param>
+    /// <param name="cmp">The comparison function to set</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_set_dupsort(nint txn, uint dbi, CompareFunction cmp);
+    
+    /// <summary>
+    /// Compares two data items according to a database's key comparison function.
+    /// </summary>
+    /// <param name="txn">A transaction handle</param>
+    /// <param name="dbi">A database handle</param>
+    /// <param name="a">The first item to compare</param>
+    /// <param name="b">The second item to compare</param>
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial int mdb_cmp(nint txn, uint dbi, ref MDBValue a, ref MDBValue b);
+    
+    /// <summary>
+    /// Compares two data items according to a database's data comparison function.
+    /// </summary>
+    /// <param name="txn">A transaction handle</param>
+    /// <param name="dbi">A database handle</param>
+    /// <param name="a">The first item to compare</param>
+    /// <param name="b">The second item to compare</param>
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial int mdb_dcmp(nint txn, uint dbi, ref MDBValue a, ref MDBValue b);
+    
+    /// <summary>
+    /// Lists all the readers in the environment and the transaction they're holding.
+    /// </summary>
+    /// <param name="env">The environment handle</param>
+    /// <param name="func">A function to call for each reader</param>
+    /// <param name="ctx">Arbitrary context data to pass to the function</param>
+    /// <returns>Number of readers that were found</returns>
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial int mdb_reader_list(nint env, nint func, nint ctx);
+    
+    /// <summary>
+    /// Checks for stale readers in the environment reader table.
+    /// </summary>
+    /// <param name="env">The environment handle</param>
+    /// <param name="dead">Address where the number of stale readers cleaned up will be stored</param>
+    /// <returns>0 on success, non-zero on failure</returns>
+    [LibraryImport(MDB_DLL_NAME)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial int mdb_reader_check(nint env, out int dead);
         
+    /// <summary>
+    /// Stores multiple contiguous data elements in a single request with a cursor.
+    /// </summary>
+    /// <param name="cursor">A cursor handle</param>
+    /// <param name="key">The key to store</param>
+    /// <param name="value">The array of data values to store</param>
+    /// <param name="flags">Special options for this operation</param>
+    /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial MDBResultCode mdb_cursor_put(nint cursor, ref MDBValue key, MDBValue[] value, CursorPutOptions flags);
@@ -163,49 +590,79 @@ public static partial class Lmdb
 public static partial class Lmdb
 {
     private const string MDB_DLL_NAME = "lmdb";
-    /// <summary>
-    /// Duplicate keys may be used in the database. (Or, from another perspective, keys may have multiple data items, stored in sorted order.) By default keys must be unique and may have only a single data item.
-    /// </summary>
-    public const int MDB_DUPSORT = 0x04;
 
     /// <summary>
-    /// This flag may only be used in combination with MDB_DUPSORT. This option tells the library that the data items for this database are all the same size, which allows further optimizations in storage and retrieval. When all data items are the same size, the MDB_GET_MULTIPLE and MDB_NEXT_MULTIPLE cursor operations may be used to retrieve multiple items at once.
+    /// Sets the size of the memory map to use for this environment.
     /// </summary>
-    public const int MDB_DUPFIXED = 0x10;
-
+    /// <param name="env">The environment handle</param>
+    /// <param name="size">The size in bytes</param>
+    /// <returns>A result code indicating success or failure</returns>
     public static MDBResultCode mdb_env_set_mapsize(nint env, long size)
     {
         return mdb_env_set_mapsize(env, (nint)size);
     }
 
+    /// <summary>
+    /// Stores key/data pairs in a database.
+    /// </summary>
+    /// <param name="txn">A transaction handle</param>
+    /// <param name="dbi">A database handle</param>
+    /// <param name="key">The key to store</param>
+    /// <param name="value">The data to store</param>
+    /// <param name="flags">Special options for this operation</param>
+    /// <returns>A result code indicating success or failure</returns>
     public static MDBResultCode mdb_put(nint txn, uint dbi, MDBValue key, MDBValue value, PutOptions flags)
     {
         return mdb_put(txn, dbi, ref key, ref value, flags);
     }
 
+    /// <summary>
+    /// Deletes items from a database.
+    /// </summary>
+    /// <param name="txn">A transaction handle</param>
+    /// <param name="dbi">A database handle</param>
+    /// <param name="key">The key to delete</param>
+    /// <param name="value">The data to delete</param>
+    /// <returns>A result code indicating success or failure</returns>
     public static MDBResultCode mdb_del(nint txn, uint dbi, MDBValue key, MDBValue value)
     {
         return mdb_del(txn, dbi, ref key, ref value);
     }
 
+    /// <summary>
+    /// Deletes items from a database.
+    /// </summary>
+    /// <param name="txn">A transaction handle</param>
+    /// <param name="dbi">A database handle</param>
+    /// <param name="key">The key to delete</param>
+    /// <returns>A result code indicating success or failure</returns>
     public static MDBResultCode mdb_del(nint txn, uint dbi, MDBValue key)
     {
-        return mdb_del(txn, dbi, ref key,0);
+        return mdb_del(txn, dbi, ref key, 0);
     }
 
+    /// <summary>
+    /// Stores key/data pairs into the database using a cursor.
+    /// </summary>
+    /// <param name="cursor">A cursor handle</param>
+    /// <param name="key">The key to store</param>
+    /// <param name="value">The data to store</param>
+    /// <param name="flags">Special options for this operation</param>
+    /// <returns>A result code indicating success or failure</returns>
     public static MDBResultCode mdb_cursor_put(nint cursor, MDBValue key, MDBValue value, CursorPutOptions flags)
     {
         return mdb_cursor_put(cursor, ref key, ref value, flags);
     }
 
     /// <summary>
-    /// store multiple contiguous data elements in a single request.
+    /// Stores multiple contiguous data elements in a single request with a cursor.
     /// May only be used with MDB_DUPFIXED.
     /// </summary>
     /// <param name="cursor">Pointer to cursor</param>
-    /// <param name="key"><see cref="MDBValue"/> key</param>
+    /// <param name="key">The key to store</param>
     /// <param name="data">This span must be pinned or stackalloc memory</param>
-    /// <param name="flags"><see cref="CursorPutOptions"/></param>
+    /// <param name="flags">Special options for this operation</param>
+    /// <returns>A result code indicating success or failure</returns>
     public static MDBResultCode mdb_cursor_put(nint cursor, ref MDBValue key, ref Span<MDBValue> data,
         CursorPutOptions flags)
     {
@@ -214,16 +671,41 @@ public static partial class Lmdb
     }
 
 #if !NET7_0_OR_GREATER
+        /// <summary>
+        /// Creates an LMDB environment handle.
+        /// </summary>
+        /// <param name="env">The address where the new handle will be stored</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_env_create(out nint env);
 
+        /// <summary>
+        /// Closes the environment and releases the memory map.
+        /// </summary>
+        /// <param name="env">The environment handle to close</param>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern void mdb_env_close(nint env);
 
+        /// <summary>
+        /// Opens an environment handle with the specified path, flags, and permissions.
+        /// </summary>
+        /// <param name="env">The environment handle to open</param>
+        /// <param name="path">The directory in which the database files reside</param>
+        /// <param name="flags">Special options for this environment</param>
+        /// <param name="mode">The UNIX permissions to set on created files</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        private static extern MDBResultCode mdb_env_open(nint env, byte[] path, EnvironmentOpenFlags flags,
+        public static extern MDBResultCode mdb_env_open(nint env, byte[] path, EnvironmentOpenFlags flags,
             UnixAccessMode mode);
 
+        /// <summary>
+        /// Opens an environment handle with the specified path, flags, and permissions.
+        /// </summary>
+        /// <param name="env">The environment handle to open</param>
+        /// <param name="path">The directory in which the database files reside</param>
+        /// <param name="flags">Special options for this environment</param>
+        /// <param name="mode">The UNIX permissions to set on created files</param>
+        /// <returns>A result code indicating success or failure</returns>
         internal static MDBResultCode mdb_env_open(nint env, string path, EnvironmentOpenFlags flags,
             UnixAccessMode mode)
         {
@@ -231,117 +713,505 @@ public static partial class Lmdb
             return mdb_env_open(env, bytes, flags, mode);
         }
 
+        /// <summary>
+        /// Sets the size of the memory map to use for this environment.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <param name="size">The size in bytes</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_env_set_mapsize(nint env, nint size);
 
+        /// <summary>
+        /// Gets the maximum number of threads/reader slots for the environment.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <param name="readers">Address where the number of readers will be stored</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_env_get_maxreaders(nint env, out uint readers);
 
+        /// <summary>
+        /// Sets the maximum number of threads/reader slots for the environment.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <param name="readers">The number of reader slots to allocate</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_env_set_maxreaders(nint env, uint readers);
 
+        /// <summary>
+        /// Sets the maximum number of named databases for the environment.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <param name="dbs">The maximum number of databases</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_env_set_maxdbs(nint env, uint dbs);
+        
+        /// <summary>
+        /// Sets environment flags.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <param name="flags">The flags to set</param>
+        /// <param name="onoff">A boolean to turn the flags on or off</param>
+        /// <returns>A result code indicating success or failure</returns>
+        [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern MDBResultCode mdb_env_set_flags(nint env, uint flags, bool onoff);
+        
+        /// <summary>
+        /// Gets environment flags.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <param name="flags">Address where the flags will be stored</param>
+        /// <returns>A result code indicating success or failure</returns>
+        [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern MDBResultCode mdb_env_get_flags(nint env, out uint flags);
+        
+        /// <summary>
+        /// Returns the path that was used in mdb_env_open.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <param name="path">Address where the path will be stored</param>
+        /// <returns>A result code indicating success or failure</returns>
+        [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern MDBResultCode mdb_env_get_path(nint env, out nint path);
+        
+        /// <summary>
+        /// Returns the file descriptor for the environment.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <param name="fd">Address where the descriptor will be stored</param>
+        /// <returns>A result code indicating success or failure</returns>
+        [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern MDBResultCode mdb_env_get_fd(nint env, out nint fd);
+        
+        /// <summary>
+        /// Returns the maximum size of keys and MDB_DUPSORT data we can write.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <returns>The maximum size of a key we can write</returns>
+        [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int mdb_env_get_maxkeysize(nint env);
+        
+        /// <summary>
+        /// Set application information associated with the environment.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <param name="ctx">An arbitrary pointer for your application's use</param>
+        /// <returns>A result code indicating success or failure</returns>
+        [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern MDBResultCode mdb_env_set_userctx(nint env, nint ctx);
+        
+        /// <summary>
+        /// Get the application information associated with the environment.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <returns>The pointer set by mdb_env_set_userctx</returns>
+        [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint mdb_env_get_userctx(nint env);
+        
+        /// <summary>
+        /// Set or reset the assert callback for the environment.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <param name="func">A callback function to run when an assertion fails</param>
+        /// <returns>A result code indicating success or failure</returns>
+        [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern MDBResultCode mdb_env_set_assert(nint env, nint func);
 
+        /// <summary>
+        /// Opens a database in the environment.
+        /// </summary>
+        /// <param name="txn">A transaction handle</param>
+        /// <param name="name">The name of the database to open (NULL for the main DB)</param>
+        /// <param name="flags">Special options for this database</param>
+        /// <param name="db">Address where the database handle will be stored</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_dbi_open(nint txn, string name, DatabaseOpenFlags flags, out uint db);
 
+        /// <summary>
+        /// Closes a database handle in the environment.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <param name="dbi">A database handle returned by mdb_dbi_open</param>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern void mdb_dbi_close(nint env, uint dbi);
+        
+        /// <summary>
+        /// Retrieves the flags for a database handle.
+        /// </summary>
+        /// <param name="txn">A transaction handle</param>
+        /// <param name="dbi">A database handle</param>
+        /// <param name="flags">Address where the flags will be stored</param>
+        /// <returns>A result code indicating success or failure</returns>
+        [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern MDBResultCode mdb_dbi_flags(nint txn, uint dbi, out uint flags);
 
+        /// <summary>
+        /// Empties or deletes a database.
+        /// </summary>
+        /// <param name="txn">A transaction handle</param>
+        /// <param name="dbi">A database handle</param>
+        /// <param name="del">If true, delete the DB from the environment; otherwise just empty it</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_drop(nint txn, uint dbi, bool del);
 
+        /// <summary>
+        /// Creates a transaction for use with the environment.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <param name="parent">Parent transaction (for nested transactions; NULL for none)</param>
+        /// <param name="flags">Special transaction flags</param>
+        /// <param name="txn">Address where the new transaction handle will be stored</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_txn_begin(nint env, nint parent, TransactionBeginFlags flags, out nint txn);
+        
+        /// <summary>
+        /// Returns the transaction's environment.
+        /// </summary>
+        /// <param name="txn">A transaction handle</param>
+        /// <returns>The environment handle</returns>
+        [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern nint mdb_txn_env(nint txn);
+        
+        /// <summary>
+        /// Returns the transaction's ID.
+        /// </summary>
+        /// <param name="txn">A transaction handle</param>
+        /// <returns>The transaction ID</returns>
+        [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int mdb_txn_id(nint txn);
 
+        /// <summary>
+        /// Commits all the operations of a transaction into the database.
+        /// </summary>
+        /// <param name="txn">A transaction handle</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_txn_commit(nint txn);
 
+        /// <summary>
+        /// Abandons all the operations of the transaction instead of saving them.
+        /// </summary>
+        /// <param name="txn">A transaction handle</param>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern void mdb_txn_abort(nint txn);
 
+        /// <summary>
+        /// Resets a read-only transaction.
+        /// </summary>
+        /// <param name="txn">A transaction handle</param>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern void mdb_txn_reset(nint txn);
 
+        /// <summary>
+        /// Renews a read-only transaction that was previously reset.
+        /// </summary>
+        /// <param name="txn">A transaction handle</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_txn_renew(nint txn);
 
+        /// <summary>
+        /// Returns the LMDB library version and version information.
+        /// </summary>
+        /// <param name="major">The library major version number</param>
+        /// <param name="minor">The library minor version number</param>
+        /// <param name="patch">The library patch version number</param>
+        /// <returns>Pointer to a version string</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern nint mdb_version(out int major, out int minor, out int patch);
 
+        /// <summary>
+        /// Returns a string describing a given error code.
+        /// </summary>
+        /// <param name="err">The error code</param>
+        /// <returns>A pointer to the error string</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern nint mdb_strerror(int err);
 
+        /// <summary>
+        /// Returns statistics about a database.
+        /// </summary>
+        /// <param name="txn">A transaction handle</param>
+        /// <param name="dbi">A database handle</param>
+        /// <param name="stat">Address where the database statistics will be stored</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_stat(nint txn, uint dbi, out MDBStat stat);
 
+        /// <summary>
+        /// Copies an LMDB environment to the specified path.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <param name="path">The directory in which the backup will reside</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        private static extern MDBResultCode mdb_env_copy(nint env, byte[] path);
+        public static extern MDBResultCode mdb_env_copy(nint env, byte[] path);
 
+        /// <summary>
+        /// Copies an LMDB environment to the specified path.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <param name="path">The directory in which the backup will reside</param>
+        /// <returns>A result code indicating success or failure</returns>
         public static MDBResultCode mdb_env_copy(nint env, string path)
         {
             var bytes = System.Text.Encoding.UTF8.GetBytes(path);
             return mdb_env_copy(env, bytes);
         }
-
+        
+        /// <summary>
+        /// Copies an LMDB environment to the specified file descriptor.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <param name="fd">The file descriptor to write to</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        private static extern MDBResultCode mdb_env_copy2(nint env, byte[] path, EnvironmentCopyFlags copyFlags);
+        public static extern MDBResultCode mdb_env_copyfd(nint env, nint fd);
+        
+        /// <summary>
+        /// Copies an LMDB environment to the specified file descriptor, with options for compaction.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <param name="fd">The file descriptor to write to</param>
+        /// <param name="copyFlags">Special options for this copy operation</param>
+        /// <returns>A result code indicating success or failure</returns>
+        [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern MDBResultCode mdb_env_copyfd2(nint env, nint fd, EnvironmentCopyFlags copyFlags);
 
+        /// <summary>
+        /// Copies an LMDB environment to the specified path, with options for compaction.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <param name="path">The directory in which the backup will reside</param>
+        /// <param name="copyFlags">Special options for this copy operation</param>
+        /// <returns>A result code indicating success or failure</returns>
+        [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern MDBResultCode mdb_env_copy2(nint env, byte[] path, EnvironmentCopyFlags copyFlags);
+
+        /// <summary>
+        /// Copies an LMDB environment to the specified path, with options for compaction.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <param name="path">The directory in which the backup will reside</param>
+        /// <param name="copyFlags">Special options for this copy operation</param>
+        /// <returns>A result code indicating success or failure</returns>
         public static MDBResultCode mdb_env_copy2(nint env, string path, EnvironmentCopyFlags copyFlags)
         {
             var bytes = System.Text.Encoding.UTF8.GetBytes(path);
             return mdb_env_copy2(env, bytes, copyFlags);
         }
 
+        /// <summary>
+        /// Returns information about the LMDB environment.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <param name="stat">Address where the environment info will be stored</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_env_info(nint env, out MDBEnvInfo stat);
 
+        /// <summary>
+        /// Returns statistics about the LMDB environment.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <param name="stat">Address where the environment statistics will be stored</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_env_stat(nint env, out MDBStat stat);
 
+        /// <summary>
+        /// Flushes all data to the environment's data file.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <param name="force">If true, force a synchronous flush; otherwise if the environment has MDB_NOSYNC or MDB_MAPASYNC, it will not be synchronous</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_env_sync(nint env, bool force);
 
+        /// <summary>
+        /// Retrieves items from a database.
+        /// </summary>
+        /// <param name="txn">A transaction handle</param>
+        /// <param name="dbi">A database handle</param>
+        /// <param name="key">The key to search for</param>
+        /// <param name="data">Address where the retrieved data will be stored</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_get(nint txn, uint dbi, ref MDBValue key, out MDBValue data);
 
+        /// <summary>
+        /// Returns count of duplicates for the current key in a cursor.
+        /// </summary>
+        /// <param name="cursor">A cursor handle</param>
+        /// <param name="countp">Address where the count will be stored</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_cursor_count(nint cursor, out int countp);
 
+        /// <summary>
+        /// Stores key/data pairs in a database.
+        /// </summary>
+        /// <param name="txn">A transaction handle</param>
+        /// <param name="dbi">A database handle</param>
+        /// <param name="key">The key to store</param>
+        /// <param name="data">The data to store</param>
+        /// <param name="flags">Special options for this operation</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_put(nint txn, uint dbi, ref MDBValue key, ref MDBValue data, PutOptions flags);
 
+        /// <summary>
+        /// Deletes items from a database.
+        /// </summary>
+        /// <param name="txn">A transaction handle</param>
+        /// <param name="dbi">A database handle</param>
+        /// <param name="key">The key to delete</param>
+        /// <param name="data">The data to delete (only needed for MDB_DUPSORT)</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_del(nint txn, uint dbi, ref MDBValue key, ref MDBValue data);
 
+        /// <summary>
+        /// Deletes items from a database.
+        /// </summary>
+        /// <param name="txn">A transaction handle</param>
+        /// <param name="dbi">A database handle</param>
+        /// <param name="key">The key to delete</param>
+        /// <param name="data">NULL pointer to delete all of the data items for the key</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_del(nint txn, uint dbi, ref MDBValue key, nint data);
 
+        /// <summary>
+        /// Creates a cursor handle for the specified transaction and database.
+        /// </summary>
+        /// <param name="txn">A transaction handle</param>
+        /// <param name="dbi">A database handle</param>
+        /// <param name="cursor">Address where the new cursor handle will be stored</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_cursor_open(nint txn, uint dbi, out nint cursor);
 
+        /// <summary>
+        /// Closes a cursor handle.
+        /// </summary>
+        /// <param name="cursor">A cursor handle to close</param>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern void mdb_cursor_close(nint cursor);
 
+        /// <summary>
+        /// Renews a cursor handle.
+        /// </summary>
+        /// <param name="txn">A transaction handle</param>
+        /// <param name="cursor">A cursor handle to renew</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_cursor_renew(nint txn, nint cursor);
-
+        
+        /// <summary>
+        /// Retrieves key/data pairs from the database using a cursor.
+        /// </summary>
+        /// <param name="cursor">A cursor handle</param>
+        /// <param name="key">The key for the current item</param>
+        /// <param name="data">The data for the current item</param>
+        /// <param name="op">The cursor operation to perform</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_cursor_get(nint cursor, ref MDBValue key, ref MDBValue data, CursorOperation op);
 
+        /// <summary>
+        /// Stores key/data pairs into the database using a cursor.
+        /// </summary>
+        /// <param name="cursor">A cursor handle</param>
+        /// <param name="key">The key to store</param>
+        /// <param name="mdbValue">The data to store</param>
+        /// <param name="flags">Special options for this operation</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_cursor_put(nint cursor, ref MDBValue key, ref MDBValue mdbValue, CursorPutOptions flags);
 
+        /// <summary>
+        /// Deletes the current key/data pair to which the cursor refers.
+        /// </summary>
+        /// <param name="cursor">A cursor handle</param>
+        /// <param name="flags">Special options for this operation</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_cursor_del(nint cursor, CursorDeleteOption flags);
 
+        /// <summary>
+        /// Sets a custom key comparison function for a database.
+        /// </summary>
+        /// <param name="txn">A transaction handle</param>
+        /// <param name="dbi">A database handle</param>
+        /// <param name="cmp">The comparison function to set</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_set_compare(nint txn, uint dbi, CompareFunction cmp);
 
+        /// <summary>
+        /// Sets a custom data comparison function for a database with MDB_DUPSORT.
+        /// </summary>
+        /// <param name="txn">A transaction handle</param>
+        /// <param name="dbi">A database handle</param>
+        /// <param name="cmp">The comparison function to set</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_set_dupsort(nint txn, uint dbi, CompareFunction cmp);
+        
+        /// <summary>
+        /// Compares two data items according to a database's key comparison function.
+        /// </summary>
+        /// <param name="txn">A transaction handle</param>
+        /// <param name="dbi">A database handle</param>
+        /// <param name="a">The first item to compare</param>
+        /// <param name="b">The second item to compare</param>
+        [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int mdb_cmp(nint txn, uint dbi, ref MDBValue a, ref MDBValue b);
+        
+        /// <summary>
+        /// Compares two data items according to a database's data comparison function.
+        /// </summary>
+        /// <param name="txn">A transaction handle</param>
+        /// <param name="dbi">A database handle</param>
+        /// <param name="a">The first item to compare</param>
+        /// <param name="b">The second item to compare</param>
+        [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int mdb_dcmp(nint txn, uint dbi, ref MDBValue a, ref MDBValue b);
+        
+        /// <summary>
+        /// Lists all the readers in the environment and the transaction they're holding.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <param name="func">A function to call for each reader</param>
+        /// <param name="ctx">Arbitrary context data to pass to the function</param>
+        /// <returns>Number of readers that were found</returns>
+        [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int mdb_reader_list(nint env, nint func, nint ctx);
+        
+        /// <summary>
+        /// Checks for stale readers in the environment reader table.
+        /// </summary>
+        /// <param name="env">The environment handle</param>
+        /// <param name="dead">Address where the number of stale readers cleaned up will be stored</param>
+        /// <returns>0 on success, non-zero on failure</returns>
+        [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int mdb_reader_check(nint env, out int dead);
 
+        /// <summary>
+        /// Stores multiple contiguous data elements in a single request with a cursor.
+        /// </summary>
+        /// <param name="cursor">A cursor handle</param>
+        /// <param name="key">The key to store</param>
+        /// <param name="value">The array of data values to store</param>
+        /// <param name="flags">Special options for this operation</param>
+        /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern MDBResultCode mdb_cursor_put(nint cursor, ref MDBValue key, MDBValue[] value, CursorPutOptions flags);
 #endif 


### PR DESCRIPTION
Opening up a PR to see how the behavior works for the FileStream overloads work across OS's before pulling in.