### PR TITLE
Updating for net10.0

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -15,11 +15,12 @@ jobs:
 
     steps:
       - name: Checkout Lightning.NET
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
+            10.0.x
             9.0.x
             8.0.x
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Restore dependencies
         run: dotnet restore

--- a/src/LightningDB.Benchmarks/LightningDB.Benchmarks.csproj
+++ b/src/LightningDB.Benchmarks/LightningDB.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>13</LangVersion>
     <LightningDBTargetRuntimeRelativePath>.\</LightningDBTargetRuntimeRelativePath>
   </PropertyGroup>

--- a/src/LightningDB.Tests/LightningDB.Tests.csproj
+++ b/src/LightningDB.Tests/LightningDB.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>13</LangVersion>
     <AssemblyName>LightningDB.Tests</AssemblyName>
     <PackageId>LightningDB.Tests</PackageId>

--- a/src/LightningDB/LightningDB.csproj
+++ b/src/LightningDB/LightningDB.csproj
@@ -4,7 +4,7 @@
     <Description>LightningDB</Description>
     <VersionPrefix>0.19.1</VersionPrefix>
     <Authors>Ilya Lukyanov;Corey Kaylor</Authors>
-    <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>13</LangVersion>
     <AssemblyName>LightningDB</AssemblyName>
     <PackageId>LightningDB</PackageId>
@@ -33,6 +33,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.6.0" />
+    <PackageReference Include="System.Memory" Version="4.6.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 </Project>

--- a/src/SecondProcess/SecondProcess.csproj
+++ b/src/SecondProcess/SecondProcess.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <LangVersion>13</LangVersion>
         <LightningDBTargetRuntimeRelativePath>.\</LightningDBTargetRuntimeRelativePath>
     </PropertyGroup>


### PR DESCRIPTION
https://github.com/CoreyKaylor/Lightning.NET/issues/188 Targets netstandard2.0, net8.0, net9.0, net10.0 and makes System.Memory conditionally applicable only to netstandard2.0