### PR TITLE
Fixed marshalling of size_t into nuint instead of int.

### DIFF
--- a/src/LightningDB.Tests/TransactionTests.cs
+++ b/src/LightningDB.Tests/TransactionTests.cs
@@ -294,7 +294,7 @@ public class TransactionTests : TestBase
 
         env.RunTransactionScenario((tx, _) =>
         {
-            tx.Id.ShouldBeGreaterThan(0);
+            tx.Id.ShouldBeGreaterThan((nuint)0);
         });
     }
 

--- a/src/LightningDB/LightningCursor.cs
+++ b/src/LightningDB/LightningCursor.cs
@@ -524,7 +524,7 @@ public class LightningCursor : IDisposable
     public MDBResultCode Count(out long value)
     {
         var result = mdb_cursor_count(_handle, out var count);
-        value = (long)count;
+        value = checked((long)count);
         return result;
     }
 

--- a/src/LightningDB/LightningCursor.cs
+++ b/src/LightningDB/LightningCursor.cs
@@ -521,9 +521,11 @@ public class LightningCursor : IDisposable
     /// </summary>
     /// <param name="value">Output parameter where the duplicate count will be stored.</param>
     /// <returns>Returns <see cref="MDBResultCode"/></returns>
-    public MDBResultCode Count(out int value)
+    public MDBResultCode Count(out long value)
     {
-        return mdb_cursor_count(_handle, out value);
+        var result = mdb_cursor_count(_handle, out var count);
+        value = (long)count;
+        return result;
     }
 
     private bool ShouldCloseCursor()

--- a/src/LightningDB/LightningTransaction.cs
+++ b/src/LightningDB/LightningTransaction.cs
@@ -422,7 +422,7 @@ public sealed class LightningTransaction : IDisposable
     /// <summary>
     /// Gets the transaction ID.
     /// </summary>
-    public int Id => mdb_txn_id(_handle);
+    public nuint Id => mdb_txn_id(_handle);
 
     /// <summary>
     /// Compares two data items according to the database's key comparison function.

--- a/src/LightningDB/Native/Lmdb.cs
+++ b/src/LightningDB/Native/Lmdb.cs
@@ -229,7 +229,7 @@ public static partial class Lmdb
     /// <returns>The transaction ID</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial int mdb_txn_id(nint txn);
+    public static partial nuint mdb_txn_id(nint txn);
 
     /// <summary>
     /// Commits all the operations of a transaction into the database.
@@ -388,7 +388,7 @@ public static partial class Lmdb
     /// <returns>A result code indicating success or failure</returns>
     [LibraryImport(MDB_DLL_NAME)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial MDBResultCode mdb_cursor_count(nint cursor, out int countp);
+    public static partial MDBResultCode mdb_cursor_count(nint cursor, out nuint countp);
 
     /// <summary>
     /// Stores key/data pairs in a database.
@@ -872,7 +872,7 @@ public static partial class Lmdb
         /// <param name="txn">A transaction handle</param>
         /// <returns>The transaction ID</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int mdb_txn_id(nint txn);
+        public static extern nuint mdb_txn_id(nint txn);
 
         /// <summary>
         /// Commits all the operations of a transaction into the database.
@@ -1040,7 +1040,7 @@ public static partial class Lmdb
         /// <param name="countp">Address where the count will be stored</param>
         /// <returns>A result code indicating success or failure</returns>
         [DllImport(MDB_DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        public static extern MDBResultCode mdb_cursor_count(nint cursor, out int countp);
+        public static extern MDBResultCode mdb_cursor_count(nint cursor, out nuint countp);
 
         /// <summary>
         /// Stores key/data pairs in a database.


### PR DESCRIPTION
This PR fixes the issue of marshalling `size_t` into appropriately sized integers, as described in [this issue](https://github.com/CoreyKaylor/Lightning.NET/issues/196).

I went with the native `nuint` type, which should map 1-to-1 with `size_t`.

For the public API, I decided to cast the `nuint` returned by `mdb_cursor_count` to a `long`, as this seems more idiomatic and convenient for users when dealing with counts. However, this is a breaking change, and if avoiding it is preferred then we could cast to an `int` instead (but see below). I do think it makes sense to return a `long` though, as (I assume) the underlying implementation supports having more than 2^32 duplicate entries in a database, in which case an `int` would truncate the value.

For the transaction id, on the other hand, I decided to propagate the `nuint` to the public API. This seems like the safest option as it makes no assumptions on the possible values that can be returned by the C implementation. In principle one could probably cast safely to a `long`, but as an identifier it isn't meant to be used in arithmetic operations anyhow. Either way, I think this needs to be a breaking change, as an `int` transaction id is unsafe on platforms where the underlying implementation can return values greater than 2^32 - this can lead to id reuse, which could become a problem for long-running processes.